### PR TITLE
WIP Add script to refresh dev deployment on code update

### DIFF
--- a/refresh_dev_deployment.py
+++ b/refresh_dev_deployment.py
@@ -1,0 +1,47 @@
+# Based on:
+# https://github.com/dagster-io/dagster/issues/3803
+
+import requests
+import json
+
+RELOAD_REPOSITORY_LOCATION_MUTATION = """
+mutation ($repositoryLocationName: String!) {
+   reloadRepositoryLocation(repositoryLocationName: $repositoryLocationName) {
+      __typename
+      ... on RepositoryLocation {
+        name
+        repositories {
+            name
+        }
+        isReloadSupported
+      }
+      ... on RepositoryLocationLoadFailure {
+          name
+          error {
+              message
+          }
+      }
+   }
+}
+"""
+
+dagit_host = "127.0.0.1"
+
+variables = {
+    "repositoryLocationName": "popgetter",
+}
+reload_res = requests.post(
+    "http://{dagit_host}:3000/graphql?query={query_string}&variables={variables}".format(
+        dagit_host=dagit_host,
+        query_string=RELOAD_REPOSITORY_LOCATION_MUTATION,
+        variables=json.dumps(variables),
+    )
+).json()
+
+did_succeed = False
+
+if reload_res:
+    # did_succeed = reload_res["data"]["reloadRepositoryLocation"]["__typename"] == "RepositoryLocation"
+    print(reload_res)
+
+print(f"Reload {'succeeded' if did_succeed else 'failed'}")


### PR DESCRIPTION
@stuartlynn This is the script we discussed to refresh the development environment when the code is updated without needing to re-launch the whole dev env.

However, the GraphQL query does not work. Dagster has a GraphQL playground here: 
http://127.0.0.1:3000/graphql

The script is taken from https://github.com/dagster-io/dagster/issues/3803
