### PR TITLE
Enable publication to PyPI

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -51,7 +51,7 @@ jobs:
 
   upload_all:
     needs: [build_wheels, make_sdist]
-    environment: pypi
+    environment: release
     permissions:
       id-token: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
The PR includes minor changes to CD GitHub Actions to deploy the package to PyPI. 