### PR TITLE
Fix getting started instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@ the repo and then install using pip, with the `--editable` option:
    `pyenv` is the most tested with popgetter). eg:
 
 ```bash
-python  -m venv popgetter_venv    # create a virtual environment called `popgetter`
+python  -m venv popgetter_venv    # create a virtual environment called `popgetter_venv`
 source popgetter_venv/bin/activate  # activate the virtual environment
 ```
 
-2. Clone the repo and then so an 'editable' install:
+2. Clone the repo and then do an 'editable' install:
 
 ```bash
 git clone https://github.com/Urban-Analytics-Technology-Platform/popgetter.git

--- a/README.md
+++ b/README.md
@@ -69,14 +69,14 @@ the repo and then install using pip, with the `--editable` option:
    `pyenv` is the most tested with popgetter). eg:
 
 ```bash
-python  -m venv popgetter   # create a virtual environment called `popgetter`
-source popgetter/bin/activate  # activate the virtual environment
+python  -m venv popgetter_venv    # create a virtual environment called `popgetter`
+source popgetter_venv/bin/activate  # activate the virtual environment
 ```
 
 2. Clone the repo and then so an 'editable' install:
 
 ```bash
-git clone git@github.com:Urban-Analytics-Technology-Platform/popgetter.git
+git clone https://github.com/Urban-Analytics-Technology-Platform/popgetter.git
 cd popgetter
 pip install -e ".[dev]"
 ```


### PR DESCRIPTION
This PR contributes towards #66, adding revisions to the ["Getting Started"](https://github.com/Urban-Analytics-Technology-Platform/popgetter?tab=readme-ov-file#getting-started) section:
- Changing the name of the venv path in step 1 to not have the same name as the default for the cloned repo
- Using `git clone` with https instead of ssh