### PR TITLE
Add script to export metadata schema in JSON format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,10 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-  "dagster >=1.6.11", # Version matched to `dagster-cloud` and `dagster-webserver` (see below)
-  "dagster-cloud >=1.6.11", # Version matched to dagster (see above)
+  # Upper version of Dasgter is pinned below 1.7.0, until the DeprecationWarning for `AssetSelection.keys()`
+  # is resolved. See https://github.com/dagster-io/dagster/releases/tag/1.7.0
+  "dagster >=1.6.11,<1.7.0", # Version matched to `dagster-cloud` and `dagster-webserver` (see below)
+  "dagster-cloud >=1.6.11,<1.7.0", # Version matched to dagster (see above)
   "dagster-azure >=0.22.11",  # Only required for production deployments, could be moved to an optional
   "pandas >=2.1,<2.2", # Pinned to 2.1 as 2.2 might be causing the failure here https://github.com/Urban-Analytics-Technology-Platform/popgetter/actions/runs/7593850248/job/20684737578
   "geopandas >=0.14.1", # This probably won't resolve to the latest version of geopandas, due to version restrictions pandas package (see above).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,8 @@ Homepage = "https://github.com/Urban-Analytics-Technology-Platform/popgetter"
 Discussions = "https://github.com/Urban-Analytics-Technology-Platform/popgetter/discussions"
 Changelog = "https://github.com/Urban-Analytics-Technology-Platform/popgetter/releases"
 
+[project.scripts]
+popgetter-export-schema = "popgetter.metadata:export_schema"
 
 [tool.maturin]
 module-name = "popgetter._core"
@@ -203,7 +205,3 @@ module_name = "popgetter"
 
 [tool.codespell]
 ignore-words-list = "ONS,ons"
-
-
-[project.scripts]
-demo_cmd = "popgetter:cmd_line_func"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,3 +201,7 @@ module_name = "popgetter"
 
 [tool.codespell]
 ignore-words-list = "ONS,ons"
+
+
+[project.scripts]
+demo_cmd = "popgetter:cmd_line_func"

--- a/python/popgetter/__init__.py
+++ b/python/popgetter/__init__.py
@@ -68,7 +68,3 @@ defs: Definitions = Definitions(
     },
     jobs=[job_be, job_us, job_uk],
 )
-
-
-def cmd_line_func():
-    print("Hello, World!")  # noqa: T201

--- a/python/popgetter/__init__.py
+++ b/python/popgetter/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from pathlib import Path
 
-from python.popgetter.utils import StagingDirResource
+from popgetter.utils import StagingDirResource
 
 __version__ = "0.1.0"
 
@@ -68,3 +68,7 @@ defs: Definitions = Definitions(
     },
     jobs=[job_be, job_us, job_uk],
 )
+
+
+def cmd_line_func():
+    print("Hello, World!")  # noqa: T201

--- a/python/popgetter/metadata.py
+++ b/python/popgetter/metadata.py
@@ -112,16 +112,17 @@ class MetricMetadata(BaseModel):
     )
 
 
-
 EXPORTED_MODELS = [CountryMetadata, DataPublisher, SourceDataRelease, MetricMetadata]
+
 
 def export_schema():
     """
     Generates JSON schema for all the models in this script and prints them to
     stdout.
     """
-    from pydantic.schema import schema
     import json
 
+    from pydantic.schema import schema
+
     top_level_schema = schema(EXPORTED_MODELS, title="popgetter_schema")
-    print(json.dumps(top_level_schema, indent=2))
+    print(json.dumps(top_level_schema, indent=2))  # noqa: T201

--- a/python/popgetter/metadata.py
+++ b/python/popgetter/metadata.py
@@ -110,3 +110,18 @@ class MetricMetadata(BaseModel):
     source_documentation_url: str = Field(
         description="The documentation of the data release in human readable form.",
     )
+
+
+
+EXPORTED_MODELS = [CountryMetadata, DataPublisher, SourceDataRelease, MetricMetadata]
+
+def export_schema():
+    """
+    Generates JSON schema for all the models in this script and prints them to
+    stdout.
+    """
+    from pydantic.schema import schema
+    import json
+
+    top_level_schema = schema(EXPORTED_MODELS, title="popgetter_schema")
+    print(json.dumps(top_level_schema, indent=2))


### PR DESCRIPTION
This small PR contains:

* A fix for an import error (top of `__init__.py`)
* A ~~toy~~ real example of using the `[project.scripts]` pattern (note that the leading `python` directory is excluded). This generates the JSON schema which is later imported by Rust (see: https://github.com/Urban-Analytics-Technology-Platform/popgetter-cli/pull/10)

For the attention of @yongrenjie 