### PR TITLE
Include module version when exporting popgetter schema

### DIFF
--- a/python/popgetter/metadata.py
+++ b/python/popgetter/metadata.py
@@ -117,12 +117,28 @@ EXPORTED_MODELS = [CountryMetadata, DataPublisher, SourceDataRelease, MetricMeta
 
 def export_schema():
     """
-    Generates JSON schema for all the models in this script and prints them to
-    stdout.
+    Generates a JSON schema for all the models in this script and outputs it to
+    the specified directory, with the filename `popgetter_{VERSION}.json`.
     """
+    import argparse
     import json
+    from pathlib import Path
 
     from pydantic.schema import schema
 
+    from popgetter import __version__
+
+    parser = argparse.ArgumentParser(description=export_schema.__doc__)
+    parser.add_argument(
+        "out_dir", help="The directory to output the schema to. Must exist."
+    )
+    args = parser.parse_args()
+    out_dir = Path(args.out_dir)
+
     top_level_schema = schema(EXPORTED_MODELS, title="popgetter_schema")
-    print(json.dumps(top_level_schema, indent=2))  # noqa: T201
+    top_level_schema["version"] = __version__
+    if not out_dir.exists():
+        error_msg = f"Directory {out_dir} does not exist."
+        raise FileNotFoundError(error_msg)
+    with (out_dir / f"popgetter_{__version__}.json").open("w") as f:
+        json.dump(top_level_schema, f, indent=2)


### PR DESCRIPTION
As per discussions yesterday — this PR:

- Adds the version number as a field to the exported JSON

- Instead of printing the JSON to stdout (I don't think there is an immediate use case for this), instead takes a directory `DIR` and outputs the JSON to the file `DIR/popgetter_{VERSION}.json`.
  - The output directory will be part of the CLI package (when this is merged :) https://github.com/Urban-Analytics-Technology-Platform/popgetter-cli/pull/12)

This makes it clear which version the schema belongs to, and reduces (but doesn't eliminate) the possibility for error downstream.