### PR TITLE
Publishing to Azure

### DIFF
--- a/python/popgetter/__init__.py
+++ b/python/popgetter/__init__.py
@@ -10,6 +10,8 @@ __version__ = "0.1.0"
 __all__ = ["__version__"]
 
 
+import os
+
 from dagster import (
     AssetsDefinition,
     AssetSelection,
@@ -26,8 +28,10 @@ from dagster._core.definitions.cacheable_assets import (
 from dagster._core.definitions.unresolved_asset_job_definition import (
     UnresolvedAssetJobDefinition,
 )
+from dagster_azure.adls2 import adls2_resource
 
 from popgetter import assets, cloud_outputs
+from popgetter.azure.azure_io_manager import adls2_io_manager
 
 all_assets: Sequence[AssetsDefinition | SourceAsset | CacheableAssetsDefinition] = [
     *load_assets_from_package_module(assets.us, group_name="us"),
@@ -64,6 +68,18 @@ defs: Definitions = Definitions(
         "pipes_subprocess_client": PipesSubprocessClient(),
         "staging_res": StagingDirResource(
             staging_dir=str(Path(__file__).parent.joinpath("staging_dir").resolve())
+        ),
+        "azure_io_manager": adls2_io_manager.configured(
+            {
+                "adls2_file_system": os.getenv("AZURE_CONTAINER"),
+                "adls2_prefix": os.getenv("AZURE_DIRECTORY"),
+            }
+        ),
+        "adls2": adls2_resource.configured(
+            {
+                "storage_account": os.getenv("AZURE_STORAGE_ACCOUNT"),
+                "credential": {"sas": os.getenv("SAS_TOKEN")},
+            }
         ),
     },
     jobs=[job_be, job_us, job_uk],

--- a/python/popgetter/azure/azure_io_manager.py
+++ b/python/popgetter/azure/azure_io_manager.py
@@ -1,0 +1,326 @@
+"""
+ADLS2IOManager without pickling based on:
+https://docs.dagster.io/_modules/dagster_azure/adls2/io_manager#ADLS2PickleIOManager
+
+"""
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+from dagster import (
+    InputContext,
+    OutputContext,
+    ResourceDependency,
+    io_manager,
+)
+from dagster import (
+    _check as check,
+)
+from dagster._annotations import deprecated
+from dagster._config.pythonic_config import ConfigurableIOManager
+from dagster._core.storage.io_manager import dagster_maintained_io_manager
+from dagster._core.storage.upath_io_manager import UPathIOManager
+from dagster._utils.cached_method import cached_method
+from dagster_azure.adls2.resources import ADLS2Resource
+from dagster_azure.adls2.utils import ResourceNotFoundError
+from pydantic import Field
+from upath import UPath
+
+# Note: this might need to be longer for some large files, but there is an issue with header's not matching
+_LEASE_DURATION = 60  # One minute
+
+# Set connection timeout to be larger than default:
+# https://github.com/Azure/azure-sdk-for-python/issues/26993#issuecomment-1289799860
+_CONNECTION_TIMEOUT = 6000
+
+
+class ADLS2InnerIOManager(UPathIOManager):
+    def __init__(
+        self,
+        file_system: Any,
+        adls2_client: Any,
+        blob_client: Any,
+        lease_client_constructor: Any,
+        prefix: str = "dagster",
+    ):
+        self.adls2_client = adls2_client
+        self.file_system_client = self.adls2_client.get_file_system_client(file_system)
+        # We also need a blob client to handle copying as ADLS doesn't have a copy API yet
+        self.blob_client = blob_client
+        self.blob_container_client = self.blob_client.get_container_client(file_system)
+        self.prefix = check.str_param(prefix, "prefix")
+
+        self.lease_client_constructor = lease_client_constructor
+        self.lease_duration = _LEASE_DURATION
+        self.file_system_client.get_file_system_properties()
+        super().__init__(base_path=UPath(self.prefix))
+
+    def get_op_output_relative_path(
+        self, context: InputContext | OutputContext
+    ) -> UPath:
+        parts = context.get_identifier()
+        run_id = parts[0]
+        output_parts = parts[1:]
+        return UPath("storage", run_id, "files", *output_parts)
+
+    def get_loading_input_log_message(self, path: UPath) -> str:
+        return f"Loading ADLS2 object from: {self._uri_for_path(path)}"
+
+    def get_writing_output_log_message(self, path: UPath) -> str:
+        return f"Writing ADLS2 object at: {self._uri_for_path(path)}"
+
+    def unlink(self, path: UPath) -> None:
+        file_client = self.file_system_client.get_file_client(path.as_posix())
+        with self._acquire_lease(file_client, is_rm=True) as lease:
+            file_client.delete_file(lease=lease, recursive=True)
+
+    def make_directory(self, path: UPath) -> None:  # noqa: ARG002
+        # It is not necessary to create directories in ADLS2
+        return None
+
+    def path_exists(self, path: UPath) -> bool:
+        try:
+            self.file_system_client.get_file_client(
+                path.as_posix()
+            ).get_file_properties()
+        except ResourceNotFoundError:
+            return False
+        return True
+
+    def _uri_for_path(self, path: UPath, protocol: str = "abfss://") -> str:
+        return "{protocol}{filesystem}@{account}.dfs.core.windows.net/{key}".format(
+            protocol=protocol,
+            filesystem=self.file_system_client.file_system_name,
+            account=self.file_system_client.account_name,
+            key=path.as_posix(),
+        )
+
+    @contextmanager
+    def _acquire_lease(self, client: Any, is_rm: bool = False) -> Iterator[str]:
+        lease_client = self.lease_client_constructor(client=client)
+        try:
+            lease_client.acquire(lease_duration=self.lease_duration)
+            yield lease_client.id
+        finally:
+            # cannot release a lease on a file that no longer exists, so need to check
+            if not is_rm:
+                lease_client.release()
+
+    def load_from_path(self, context: InputContext, path: UPath) -> bytes | None:
+        if context.dagster_type.typing_type == type(None):
+            return None
+        file = self.file_system_client.get_file_client(path.as_posix())
+        stream = file.download_file()
+        # return pickle.loads(stream.readall())
+        return stream.readall()
+
+    def dump_to_path(self, context: OutputContext, obj: bytes, path: UPath) -> None:
+        if self.path_exists(path):
+            context.log.warning(f"Removing existing ADLS2 key: {path}")  # noqa: G004
+            self.unlink(path)
+
+        # pickled_obj = pickle.dumps(obj, PICKLE_PROTOCOL)
+        pickled_obj = obj
+        file = self.file_system_client.create_file(path.as_posix())
+        with self._acquire_lease(file) as lease:
+            # Note: chunk_size can also be specified, see API for Azure SDK for Python, DataLakeFileClient:
+            # https://learn.microsoft.com/en-us/python/api/azure-storage-file-datalake/azure.storage.filedatalake.datalakefileclient
+            file.upload_data(
+                pickled_obj,
+                lease=lease,
+                overwrite=True,
+                connection_timeout=_CONNECTION_TIMEOUT,
+            )
+
+
+class ADLS2IOManager(ConfigurableIOManager):
+    """Persistent IO manager using Azure Data Lake Storage Gen2 for storage.
+
+    Serializes objects via pickling. Suitable for objects storage for distributed executors, so long
+    as each execution node has network connectivity and credentials for ADLS and the backing
+    container.
+
+    Assigns each op output to a unique filepath containing run ID, step key, and output name.
+    Assigns each asset to a single filesystem path, at "<base_dir>/<asset_key>". If the asset key
+    has multiple components, the final component is used as the name of the file, and the preceding
+    components as parent directories under the base_dir.
+
+    Subsequent materializations of an asset will overwrite previous materializations of that asset.
+    With a base directory of "/my/base/path", an asset with key
+    `AssetKey(["one", "two", "three"])` would be stored in a file called "three" in a directory
+    with path "/my/base/path/one/two/".
+
+    Example usage:
+
+    1. Attach this IO manager to a set of assets.
+
+    .. code-block:: python
+
+        from dagster import Definitions, asset
+        from dagster_azure.adls2 import ADLS2PickleIOManager, adls2_resource
+
+
+        @asset
+        def asset1():
+            # create df ...
+            return df
+
+
+        @asset
+        def asset2(asset1):
+            return df[:5]
+
+
+        defs = Definitions(
+            assets=[asset1, asset2],
+            resources={
+                "io_manager": ADLS2PickleIOManager(
+                    adls2_file_system="my-cool-fs", adls2_prefix="my-cool-prefix"
+                ),
+                "adls2": adls2_resource,
+            },
+        )
+
+
+    2. Attach this IO manager to your job to make it available to your ops.
+
+    .. code-block:: python
+
+        from dagster import job
+        from dagster_azure.adls2 import ADLS2PickleIOManager, adls2_resource
+
+
+        @job(
+            resource_defs={
+                "io_manager": ADLS2PickleIOManager(
+                    adls2_file_system="my-cool-fs", adls2_prefix="my-cool-prefix"
+                ),
+                "adls2": adls2_resource,
+            },
+        )
+        def my_job():
+            ...
+    """
+
+    adls2: ResourceDependency[ADLS2Resource]
+    adls2_file_system: str = Field(description="ADLS Gen2 file system name.")
+    adls2_prefix: str = Field(
+        default="dagster", description="ADLS Gen2 file system prefix to write to."
+    )
+
+    @classmethod
+    def _is_dagster_maintained(cls) -> bool:
+        return True
+
+    @property
+    @cached_method
+    def _internal_io_manager(self) -> ADLS2InnerIOManager:
+        return ADLS2InnerIOManager(
+            self.adls2_file_system,
+            self.adls2.adls2_client,
+            self.adls2.blob_client,
+            self.adls2.lease_client_constructor,
+            self.adls2_prefix,
+        )
+
+    def load_input(self, context: InputContext) -> Any:
+        return self._internal_io_manager.load_input(context)
+
+    def handle_output(self, context: OutputContext, obj: Any) -> None:
+        self._internal_io_manager.handle_output(context, obj)
+
+
+@deprecated(
+    breaking_version="2.0",
+    additional_warn_text="Please use GCSPickleIOManager instead.",
+)
+class ConfigurableADLS2IOManager(ADLS2IOManager):
+    """Renamed to ADLS2PickleIOManager. See ADLS2PickleIOManager for documentation."""
+
+
+@dagster_maintained_io_manager
+@io_manager(
+    config_schema=ADLS2IOManager.to_config_schema(),
+    required_resource_keys={"adls2"},
+)
+def adls2_io_manager(init_context):
+    """Persistent IO manager using Azure Data Lake Storage Gen2 for storage.
+
+    Serializes objects via pickling. Suitable for objects storage for distributed executors, so long
+    as each execution node has network connectivity and credentials for ADLS and the backing
+    container.
+
+    Assigns each op output to a unique filepath containing run ID, step key, and output name.
+    Assigns each asset to a single filesystem path, at "<base_dir>/<asset_key>". If the asset key
+    has multiple components, the final component is used as the name of the file, and the preceding
+    components as parent directories under the base_dir.
+
+    Subsequent materializations of an asset will overwrite previous materializations of that asset.
+    With a base directory of "/my/base/path", an asset with key
+    `AssetKey(["one", "two", "three"])` would be stored in a file called "three" in a directory
+    with path "/my/base/path/one/two/".
+
+    Example usage:
+
+    1. Attach this IO manager to a set of assets.
+
+    .. code-block:: python
+
+        from dagster import Definitions, asset
+        from dagster_azure.adls2 import adls2_pickle_io_manager, adls2_resource
+
+
+        @asset
+        def asset1():
+            # create df ...
+            return df
+
+
+        @asset
+        def asset2(asset1):
+            return df[:5]
+
+
+        defs = Definitions(
+            assets=[asset1, asset2],
+            resources={
+                "io_manager": adls2_pickle_io_manager.configured(
+                    {"adls2_file_system": "my-cool-fs", "adls2_prefix": "my-cool-prefix"}
+                ),
+                "adls2": adls2_resource,
+            },
+        )
+
+
+    2. Attach this IO manager to your job to make it available to your ops.
+
+    .. code-block:: python
+
+        from dagster import job
+        from dagster_azure.adls2 import adls2_pickle_io_manager, adls2_resource
+
+
+        @job(
+            resource_defs={
+                "io_manager": adls2_pickle_io_manager.configured(
+                    {"adls2_file_system": "my-cool-fs", "adls2_prefix": "my-cool-prefix"}
+                ),
+                "adls2": adls2_resource,
+            },
+        )
+        def my_job():
+            ...
+    """
+    adls_resource = init_context.resources.adls2
+    adls2_client = adls_resource.adls2_client
+    blob_client = adls_resource.blob_client
+    lease_client = adls_resource.lease_client_constructor
+    return ADLS2InnerIOManager(
+        init_context.resource_config["adls2_file_system"],
+        adls2_client,
+        blob_client,
+        lease_client,
+        init_context.resource_config.get("adls2_prefix"),
+    )

--- a/python/popgetter/cloud_outputs.py
+++ b/python/popgetter/cloud_outputs.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import os
+import tempfile
+import uuid
 from pathlib import Path
 
 import geopandas as gpd
+import pandas as pd
 from dagster import (
     AssetKey,
-    AssetOut,
     AssetSelection,
     Config,
     DefaultSensorStatus,
@@ -20,22 +23,21 @@ from dagster import (
     define_asset_job,
     load_assets_from_current_module,
     local_file_manager,
-    multi_asset,
     multi_asset_sensor,
 )
 from dagster_azure.adls2 import adls2_file_manager
 from icecream import ic
 from slugify import slugify
 
+# See https://docs.dagster.io/_apidocs/libraries/dagster-azure#dagster_azure.adls2.adls2_file_manager
 resources = {
     "DEV": {"publishing_file_manager": local_file_manager},
     "PRODUCTION": {
-        "publishing_file_manager": adls2_file_manager
-        # See https://docs.dagster.io/_apidocs/libraries/dagster-azure#dagster_azure.adls2.adls2_file_manager
-        # storage_account="tbc",  # The storage account name.
-        # credential={},  # The credential used to authenticate the connection.
-        # adls2_file_system="tbc",
-        # adls2_prefix="tbc",
+        "publishing_file_manager": adls2_file_manager,
+        "storage_account": "popgetter",
+        "credential": os.getenv("SAS_TOKEN"),
+        "adls2_file_system": "tbc",
+        "adls2_prefix": "tbc",
     },
 }
 
@@ -80,7 +82,10 @@ assets_to_monitor = (
     # Belgium Geography + tables
     | (
         AssetSelection.groups("be")
-        & AssetSelection.keys("be/source_table").downstream(include_self=False)
+        # Note: include_self=True as the geodataframe is currently not output for
+        # derived tables but only for source table:
+        # be-source-table-https-statbel-fgov-be-node-4726
+        & AssetSelection.keys("be/source_table").downstream(include_self=True)
     )
 )
 
@@ -226,84 +231,44 @@ def upstream_df(context):
     raise ValueError(err_msg)
 
 
-@multi_asset(
-    outs={
-        "parquet_path": AssetOut(is_required=False),
-        "flatgeobuff_path": AssetOut(is_required=False),
-        "geojson_seq_path": AssetOut(is_required=False),
-    },
-    can_subset=True,
-    required_resource_keys={"staging_res"},
-    partitions_def=publishing_partition,
-)
-def cartography_in_cloud_formats(context, upstream_df):
-    """ "
-    Returns dict of parquet, FlatGeobuf and GeoJSONSeq paths
-    """
-    staging_res = context.resources.staging_res
-    # ic(staging_res)
-    # ic(staging_res.staging_dir)
-    staging_dir_str = staging_res.staging_dir
-
-    staging_dir = Path(staging_dir_str)
-
-    # Extract the selected keys from the context
-    selected_keys = [
-        key.to_user_string() for key in context.op_execution_context.selected_asset_keys
-    ]
-
-    def _parquet_helper(output_path):
-        upstream_df.to_parquet(output_path)
-
-    def _flatgeobuff_helper(output_path):
-        if output_path.exists():
-            if output_path.is_dir():
-                # Assuming that the directory is only one level deep
-                for file in output_path.iterdir():
-                    file.unlink()
-                output_path.rmdir()
-            else:
-                output_path.unlink()
-        upstream_df.to_file(output_path, driver="FlatGeobuf")
-
-    def _geojson_seq_helper(output_path):
-        upstream_df.to_file(output_path, driver="GeoJSONSeq")
-
-    # helper functions
-    format_helpers = {
-        "parquet_path": ("parquet", _parquet_helper),
-        "flatgeobuff_path": ("flatgeobuff", _flatgeobuff_helper),
-        "geojson_seq_path": ("geojsonseq", _geojson_seq_helper),
-    }
-
-    for output_type in selected_keys:
-        # output_type = output_asset_key.to_user_string()
-        context.log.debug(ic(f"yielding {output_type}"))
-        extension, helper_function = format_helpers[output_type]
-        output_file_base = context.partition_key
-        output_path = staging_dir / f"{output_file_base}.{extension}"
-        output_path.parent.mkdir(exist_ok=True)
-        output_path.touch(exist_ok=True)
-        helper_function(output_path)
-
-        yield Output(
-            value=output_path,
-            output_name=output_type,
-            metadata={
-                "file_type": output_type,
-                "file_path": output_path,
-            },
-        )
-
-    ic("end of cartography_in_cloud_formats")
+@asset(io_manager_key="azure_io_manager")
+def test_azure():
+    return pd.DataFrame({"col1": [1, 2], "col2": [3, 4]}).to_parquet(None)
 
 
-# def upload_cartography_to_cloud(context, cartography_in_cloud_formats):
-#     """
-#     Uploads the cartography files to the cloud.
-#     """
-#     log_msg = f"Uploading cartography to the cloud - {cartography_in_cloud_formats}"
-#     context.log.info(log_msg)
+@asset(io_manager_key="azure_io_manager")
+def test_azure_large():
+    return b"0" * (45 * 1024 * 1024 + 100)
+
+
+def df_to_bytes(df: gpd.GeoDataFrame, output_type: str) -> bytes:
+    tmp = tempfile.NamedTemporaryFile(prefix=str(uuid.uuid4()))
+    if output_type.lower() == "parquet":
+        df.to_parquet(tmp.name + ".parquet")
+    elif output_type.lower() == "flatgeobuf":
+        df.to_file(tmp.name + ".flatgeobuf", driver="FlatGeobuf")
+    elif output_type.lower() == "geojsonseq":
+        df.to_file(tmp.name + ".geojsonseq", driver="GeoJSONSeq")
+    else:
+        value_error: str = f"'{output_type}' is not currently supported."
+        raise ValueError(value_error)
+    with Path(tmp.name).open(mode="rb") as f:
+        return f.read()
+
+
+@asset(io_manager_key="azure_io_manager", partitions_def=publishing_partition)
+def parquet(context, upstream_df):  # noqa: ARG001
+    return df_to_bytes(upstream_df, "parquet")
+
+
+@asset(io_manager_key="azure_io_manager", partitions_def=publishing_partition)
+def flatgeobuf(context, upstream_df):  # noqa: ARG001
+    return df_to_bytes(upstream_df, "flatgeobuf")
+
+
+@asset(io_manager_key="azure_io_manager", partitions_def=publishing_partition)
+def geojsonseq(context, upstream_df):  # noqa: ARG001
+    return df_to_bytes(upstream_df, "geojsonseq")
 
 
 # Not working yet - need to figure out questions about how we run docker
@@ -312,7 +277,6 @@ def cartography_in_cloud_formats(context, upstream_df):
 # def generate_pmtiles(context, geojson_seq_path):
 #     client = docker.from_env()
 #     mount_folder = Path(geojson_seq_path).parent.resolve()
-
 #     container = client.containers.run(
 #         "stuartlynn/tippecanoe:latest",
 #         "tippecanoe -o tracts.pmtiles tracts.geojsonseq",
@@ -320,7 +284,6 @@ def cartography_in_cloud_formats(context, upstream_df):
 #         detach=True,
 #         remove=True,
 #     )
-
 #     output = container.attach(stdout=True, stream=True, logs=True)
 #     for line in output:
 #         context.log.info(line)


### PR DESCRIPTION
Closes #75.

Initial version includes:
- [x] Revise cloud outputs to directly output to either local file system (`ENV=dev`) or Azure (`ENV=prod`)
- [x] Configuration of Azure storage with environment variables
- [x] Add implementation of `ADLS2IOManager` for writing to Azure that does not pickle outputs
- [ ] Revise IO manager to name file outputs in accordance with https://github.com/Urban-Analytics-Technology-Platform/popgetter/pull/82#issuecomment-2085975263