### PR TITLE
Implement decorators to 'mark' assets for publishing

### DIFF
--- a/python/popgetter/assets/be/census_derived.py
+++ b/python/popgetter/assets/be/census_derived.py
@@ -16,6 +16,7 @@ from dagster import (
 from icecream import ic
 
 from popgetter.metadata import MetricMetadata, SourceDataRelease, metadata_to_dataframe
+from popgetter.cloud_outputs import publish_metrics
 
 from .belgium import asset_prefix
 from .census_tables import dataset_node_partition
@@ -314,6 +315,7 @@ def derived_metrics_by_partition(
     return derived_mmd, joined_metrics
 
 
+@publish_metrics
 @asset(
     ins={
         "derived_metrics_by_partition": AssetIn(

--- a/python/popgetter/assets/be/census_derived.py
+++ b/python/popgetter/assets/be/census_derived.py
@@ -15,7 +15,7 @@ from dagster import (
 )
 from icecream import ic
 
-from popgetter.cloud_outputs import publish_metrics
+from popgetter.cloud_outputs import send_to_metrics_sensor
 from popgetter.metadata import MetricMetadata, SourceDataRelease, metadata_to_dataframe
 
 from .belgium import asset_prefix
@@ -315,7 +315,7 @@ def derived_metrics_by_partition(
     return derived_mmd, joined_metrics
 
 
-@publish_metrics
+@send_to_metrics_sensor
 @asset(
     ins={
         "derived_metrics_by_partition": AssetIn(

--- a/python/popgetter/assets/be/census_derived.py
+++ b/python/popgetter/assets/be/census_derived.py
@@ -15,8 +15,8 @@ from dagster import (
 )
 from icecream import ic
 
-from popgetter.metadata import MetricMetadata, SourceDataRelease, metadata_to_dataframe
 from popgetter.cloud_outputs import publish_metrics
+from popgetter.metadata import MetricMetadata, SourceDataRelease, metadata_to_dataframe
 
 from .belgium import asset_prefix
 from .census_tables import dataset_node_partition

--- a/python/popgetter/assets/be/census_geometry.py
+++ b/python/popgetter/assets/be/census_geometry.py
@@ -14,7 +14,7 @@ from dagster import (
 )
 from icecream import ic
 
-from popgetter.cloud_outputs import publish_geometries, publish_metadata
+from popgetter.cloud_outputs import send_to_geometry_sensor, send_to_metadata_sensor
 from popgetter.metadata import (
     GeometryMetadata,
     SourceDataRelease,
@@ -87,7 +87,7 @@ BELGIUM_GEOMETRY_LEVELS = {
 }
 
 
-@publish_geometries
+@send_to_geometry_sensor
 @asset(
     ins={
         "sector_geometries": AssetIn(
@@ -166,7 +166,7 @@ def geometry(
     return geometries_to_return
 
 
-@publish_metadata
+@send_to_metadata_sensor
 @asset(key_prefix=asset_prefix)
 def source_data_releases(
     geometry: list[tuple[GeometryMetadata, gpd.GeoDataFrame, pd.DataFrame]]

--- a/python/popgetter/assets/be/census_geometry.py
+++ b/python/popgetter/assets/be/census_geometry.py
@@ -22,6 +22,7 @@ from popgetter.utils import markdown_from_plot
 
 from .belgium import asset_prefix
 from .census_tables import publisher
+from popgetter.cloud_outputs import publish_metadata, publish_geometries
 
 
 @dataclass
@@ -86,6 +87,7 @@ BELGIUM_GEOMETRY_LEVELS = {
 }
 
 
+@publish_geometries
 @asset(
     ins={
         "sector_geometries": AssetIn(
@@ -164,6 +166,7 @@ def geometry(
     return geometries_to_return
 
 
+@publish_metadata
 @asset(key_prefix=asset_prefix)
 def source_data_releases(
     geometry: list[tuple[GeometryMetadata, gpd.GeoDataFrame, pd.DataFrame]]

--- a/python/popgetter/assets/be/census_geometry.py
+++ b/python/popgetter/assets/be/census_geometry.py
@@ -14,6 +14,7 @@ from dagster import (
 )
 from icecream import ic
 
+from popgetter.cloud_outputs import publish_geometries, publish_metadata
 from popgetter.metadata import (
     GeometryMetadata,
     SourceDataRelease,
@@ -22,7 +23,6 @@ from popgetter.utils import markdown_from_plot
 
 from .belgium import asset_prefix
 from .census_tables import publisher
-from popgetter.cloud_outputs import publish_metadata, publish_geometries
 
 
 @dataclass

--- a/python/popgetter/assets/be/census_tables.py
+++ b/python/popgetter/assets/be/census_tables.py
@@ -25,6 +25,7 @@ from popgetter.metadata import (
     DataPublisher,
 )
 from popgetter.utils import extract_main_file_from_zip, markdown_from_plot
+from popgetter.cloud_outputs import publish_metadata
 
 from .belgium import asset_prefix, country
 
@@ -40,6 +41,7 @@ opendata_catalog_root = URIRef("http://data.gov.be/catalog/statbelopen")
 dataset_node_partition = DynamicPartitionsDefinition(name="dataset_nodes")
 
 
+@publish_metadata
 @asset(key_prefix=asset_prefix)
 def country_metadata() -> CountryMetadata:
     """
@@ -48,6 +50,7 @@ def country_metadata() -> CountryMetadata:
     return country
 
 
+@publish_metadata
 @asset(key_prefix=asset_prefix)
 def data_publisher() -> DataPublisher:
     """

--- a/python/popgetter/assets/be/census_tables.py
+++ b/python/popgetter/assets/be/census_tables.py
@@ -20,7 +20,7 @@ from icecream import ic
 from rdflib import Graph, URIRef
 from rdflib.namespace import DCAT, DCTERMS, SKOS
 
-from popgetter.cloud_outputs import publish_metadata
+from popgetter.cloud_outputs import send_to_metadata_sensor
 from popgetter.metadata import (
     CountryMetadata,
     DataPublisher,
@@ -41,7 +41,7 @@ opendata_catalog_root = URIRef("http://data.gov.be/catalog/statbelopen")
 dataset_node_partition = DynamicPartitionsDefinition(name="dataset_nodes")
 
 
-@publish_metadata
+@send_to_metadata_sensor
 @asset(key_prefix=asset_prefix)
 def country_metadata() -> CountryMetadata:
     """
@@ -50,7 +50,7 @@ def country_metadata() -> CountryMetadata:
     return country
 
 
-@publish_metadata
+@send_to_metadata_sensor
 @asset(key_prefix=asset_prefix)
 def data_publisher() -> DataPublisher:
     """

--- a/python/popgetter/assets/be/census_tables.py
+++ b/python/popgetter/assets/be/census_tables.py
@@ -20,12 +20,12 @@ from icecream import ic
 from rdflib import Graph, URIRef
 from rdflib.namespace import DCAT, DCTERMS, SKOS
 
+from popgetter.cloud_outputs import publish_metadata
 from popgetter.metadata import (
     CountryMetadata,
     DataPublisher,
 )
 from popgetter.utils import extract_main_file_from_zip, markdown_from_plot
-from popgetter.cloud_outputs import publish_metadata
 
 from .belgium import asset_prefix, country
 

--- a/python/popgetter/cloud_outputs/__init__.py
+++ b/python/popgetter/cloud_outputs/__init__.py
@@ -33,16 +33,16 @@ metrics_sensor = metrics_factory.create_sensor()
 metrics_asset = metrics_factory.create_publishing_asset()
 
 
-def publish_metadata(asset: AssetsDefinition):
+def send_to_metadata_sensor(asset: AssetsDefinition):
     metadata_factory.monitored_asset_keys.append(asset.key)
     return asset
 
 
-def publish_geometries(asset: AssetsDefinition):
+def send_to_geometry_sensor(asset: AssetsDefinition):
     geometry_factory.monitored_asset_keys.append(asset.key)
     return asset
 
 
-def publish_metrics(asset: AssetsDefinition):
+def send_to_metrics_sensor(asset: AssetsDefinition):
     metrics_factory.monitored_asset_keys.append(asset.key)
     return asset

--- a/python/popgetter/cloud_outputs/__init__.py
+++ b/python/popgetter/cloud_outputs/__init__.py
@@ -2,12 +2,10 @@ from __future__ import annotations
 
 from .sensor_class import CloudAssetSensor
 
+from dagster import AssetsDefinition
+
+
 metadata_factory = CloudAssetSensor(
-    asset_names_to_monitor=[
-        "be/country_metadata",
-        "be/data_publisher",
-        "be/source_data_releases",
-    ],
     io_manager_key="metadata_io_manager",
     prefix="metadata",
     interval=20,
@@ -17,9 +15,6 @@ metadata_sensor = metadata_factory.create_sensor()
 metadata_asset = metadata_factory.create_publishing_asset()
 
 geometry_factory = CloudAssetSensor(
-    asset_names_to_monitor=[
-        "be/geometry",
-    ],
     io_manager_key="geometry_io_manager",
     prefix="geometry",
     interval=60,
@@ -28,10 +23,8 @@ geometry_factory = CloudAssetSensor(
 geometry_sensor = geometry_factory.create_sensor()
 geometry_asset = geometry_factory.create_publishing_asset()
 
+
 metrics_factory = CloudAssetSensor(
-    asset_names_to_monitor=[
-        "be/metrics",
-    ],
     io_manager_key="metrics_io_manager",
     prefix="metrics",
     interval=60,
@@ -39,3 +32,18 @@ metrics_factory = CloudAssetSensor(
 
 metrics_sensor = metrics_factory.create_sensor()
 metrics_asset = metrics_factory.create_publishing_asset()
+
+
+def publish_metadata(asset: AssetsDefinition):
+    metadata_factory.monitored_asset_keys.append(asset.key)
+    return asset
+
+
+def publish_geometries(asset: AssetsDefinition):
+    geometry_factory.monitored_asset_keys.append(asset.key)
+    return asset
+
+
+def publish_metrics(asset: AssetsDefinition):
+    metrics_factory.monitored_asset_keys.append(asset.key)
+    return asset

--- a/python/popgetter/cloud_outputs/__init__.py
+++ b/python/popgetter/cloud_outputs/__init__.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-from .sensor_class import CloudAssetSensor
-
 from dagster import AssetsDefinition
 
+from .sensor_class import CloudAssetSensor
 
 metadata_factory = CloudAssetSensor(
     io_manager_key="metadata_io_manager",

--- a/python/popgetter/cloud_outputs/sensor_class.py
+++ b/python/popgetter/cloud_outputs/sensor_class.py
@@ -113,7 +113,7 @@ class CloudAssetSensor:
                     # to this, we ensure we don't run the publishing sensor
                     # multiple times for the same asset materialisation.
                     yield RunRequest(
-                        run_key=execution_value.run_id,
+                        run_key=f"{monitored_asset_name}_{execution_value.run_id}",
                         partition_key="/".join(monitored_asset_key.path),
                     )
                     context.advance_cursor({monitored_asset_key: execution_value})

--- a/python/popgetter/cloud_outputs/sensor_class.py
+++ b/python/popgetter/cloud_outputs/sensor_class.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
 from functools import reduce
+from typing import Sequence
 
 from dagster import (
+    AssetKey,
     AssetSelection,
     DefaultSensorStatus,
     Output,
     RunRequest,
-    StaticPartitionsDefinition,
+    DynamicPartitionsDefinition,
     asset,
     multi_asset_sensor,
 )
@@ -44,23 +46,21 @@ class CloudAssetSensor:
 
     def __init__(
         self,
-        asset_names_to_monitor: list[str],
+        # asset_names_to_monitor: list[str],
         io_manager_key: str,
         prefix: str,
         interval: int,
     ):
-        self.asset_names_to_monitor = asset_names_to_monitor
+        # self.asset_names_to_monitor = asset_names_to_monitor
         self.io_manager_key = io_manager_key
         self.publishing_asset_name = f"publish_{prefix}"
         self.sensor_name = f"sensor_{prefix}"
         self.interval = interval
+        self.monitored_asset_keys: Sequence[AssetKey] = []
 
-        self.partition_definition = StaticPartitionsDefinition(
-            self.asset_names_to_monitor
-        )
-        self.assets_to_monitor = reduce(
-            lambda x, y: x | y,
-            [AssetSelection.keys(k) for k in self.asset_names_to_monitor],
+        self.partition_definition_name = f"{prefix}_partitions"
+        self.partition_definition = DynamicPartitionsDefinition(
+            name=self.partition_definition_name
         )
 
     def create_publishing_asset(self):
@@ -80,24 +80,45 @@ class CloudAssetSensor:
 
     def create_sensor(self):
         @multi_asset_sensor(
-            monitored_assets=self.assets_to_monitor,
+            # Because the list of monitored assets is dynamically generated
+            # using self.monitored_asset_keys, we don't pass it here.
+            monitored_assets=[], 
             request_assets=AssetSelection.keys(self.publishing_asset_name),
             name=self.sensor_name,
             minimum_interval_seconds=self.interval,
             default_status=DefaultSensorStatus.RUNNING,
         )
         def inner_sensor(context):
-            asset_events = context.latest_materialization_records_by_key()
-            for asset_key, execution_value in asset_events.items():
-                # Assets which were materialised since the last time the sensor
-                # was run will have non-None execution_values (it will be an
-                # dagster.EventLogRecord class, which contains more information
-                # if needed).
-                if execution_value is not None:
-                    yield RunRequest(
-                        run_key=None,
-                        partition_key="/".join(asset_key.path),
+            # Get info about the latest materialisations of all the assets
+            # we're interested in
+            asset_events = context.latest_materialization_records_by_key(
+                self.monitored_asset_keys
+            )
+
+            for monitored_asset_key, execution_value in asset_events.items():
+                monitored_asset_name = "/".join(monitored_asset_key.path)
+
+                # Add the monitored asset to the list of dynamic partitions of
+                # the publishing asset, if it's not already there.
+                if monitored_asset_name not in context.instance.get_dynamic_partitions(
+                    self.partition_definition_name
+                ):
+                    context.instance.add_dynamic_partitions(
+                        partitions_def_name=self.partition_definition_name,
+                        partition_keys=[monitored_asset_name],
                     )
-                    context.advance_cursor({asset_key: execution_value})
+
+                if execution_value is not None:
+                    # Trigger a run request for the publishing asset, if it has
+                    # been materialised.
+                    # execution_value.run_id contains the run ID of the last time
+                    # the monitored asset was materialised. By setting the run_key
+                    # to this, we ensure we don't run the publishing sensor
+                    # multiple times for the same asset materialisation.
+                    yield RunRequest(
+                        run_key=execution_value.run_id,
+                        partition_key="/".join(monitored_asset_key.path),
+                    )
+                    context.advance_cursor({monitored_asset_key: execution_value})
 
         return inner_sensor

--- a/python/popgetter/cloud_outputs/sensor_class.py
+++ b/python/popgetter/cloud_outputs/sensor_class.py
@@ -1,15 +1,12 @@
 from __future__ import annotations
 
-from functools import reduce
-from typing import Sequence
-
 from dagster import (
     AssetKey,
     AssetSelection,
     DefaultSensorStatus,
+    DynamicPartitionsDefinition,
     Output,
     RunRequest,
-    DynamicPartitionsDefinition,
     asset,
     multi_asset_sensor,
 )
@@ -56,7 +53,7 @@ class CloudAssetSensor:
         self.publishing_asset_name = f"publish_{prefix}"
         self.sensor_name = f"sensor_{prefix}"
         self.interval = interval
-        self.monitored_asset_keys: Sequence[AssetKey] = []
+        self.monitored_asset_keys: list[AssetKey] = []
 
         self.partition_definition_name = f"{prefix}_partitions"
         self.partition_definition = DynamicPartitionsDefinition(
@@ -82,7 +79,7 @@ class CloudAssetSensor:
         @multi_asset_sensor(
             # Because the list of monitored assets is dynamically generated
             # using self.monitored_asset_keys, we don't pass it here.
-            monitored_assets=[], 
+            monitored_assets=[],
             request_assets=AssetSelection.keys(self.publishing_asset_name),
             name=self.sensor_name,
             minimum_interval_seconds=self.interval,


### PR DESCRIPTION
# Overview

Before this PR, we had to manually specify a list of asset names to monitor.

https://github.com/Urban-Analytics-Technology-Platform/popgetter/blob/aa1df17b42a80de579286d0fea5600efc6f35e18/python/popgetter/cloud_outputs/__init__.py#L5-L14

This PR implements three decorators like these (one for metadata, one for geometries, one for metrics):

https://github.com/Urban-Analytics-Technology-Platform/popgetter/blob/5d0a824b05a811da6faf2955dfef11f921a8524f/python/popgetter/cloud_outputs/__init__.py#L37-L39

So that at the point of defining the _asset_, we can do this:

https://github.com/Urban-Analytics-Technology-Platform/popgetter/blob/5d0a824b05a811da6faf2955dfef11f921a8524f/python/popgetter/assets/be/census_tables.py#L44-L50

And then the asset is magically added to the sensor at runtime!

I've tested this with the local IO managers and the sensors have exactly the same behaviour as before, it should be the same with Azure too as this PR does not touch any of the IO manager logic.

--------------------------

# my 2p

I'm kind of in two minds about this PR.

- 😄 I like the fact that implementing a new country doesn't force you to go into the `cloud_outputs` folder to change the code there, and it's entirely standalone.

- 😄 I like that the decorator is agnostic towards the name of the asset or function, so if we update the DAG we can change those names without worrying about it.

- 😐 I'm in general not a huge fan of Python decorators, but since Dagster already uses decorators everywhere I think this is ok.

- 😠 I don't like that the code under the hood is ugly (dynamic partitions ...) and in some ways I like the simplicity of having the asset names be explicitly mentioned somewhere.

Overall, though, I think it's a positive change and I suspect the code-under-the-hood part is a write-once thing that doesn't have to be changed again. I commented extensively just in case anyone ever needs to update it again.