### PR TITLE
Improvements to publishing pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,8 @@ jobs:
         run: >-
           python -m pytest -ra --cov --cov-report=xml --cov-report=term
           --durations=20
+        env:
+          DAGSTER_HOME: ${{ runner.temp }}
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v4.5.0

--- a/docs/new_country.md
+++ b/docs/new_country.md
@@ -157,4 +157,4 @@ Naturally, the implementation of this base class makes some assumptions about
 the structure of the data and the relationships between them. We have found
 these to be applicable across multiple countries we have worked with. However,
 if these are not suitable for your data, you can still define the assets
-manually as shown above!
+manually as shown above! It is also possible to override part of the base class with manual asset implementations to include variations from the structure assumed by the base class.

--- a/docs/new_country.md
+++ b/docs/new_country.md
@@ -1,0 +1,160 @@
+# Defining a new country
+
+## Overview
+
+In general, each self-contained set of census data will correspond to a single
+territory, which we loosely refer to as a 'country'. Each country in popgetter
+will have a group of assets that it publishes. To add a new country to
+popgetter, you will need to:
+
+- Create a new subdirectory `python/popgetter/assets/{COUNTRY_ID}`.
+  `{COUNTRY_ID}` here is a lowercase, unique identifier for the country. (In
+  principle, we would like this to correspond to the
+  `popgetter.metadata.CountryMetadata.id` computed field: thus, for an actual
+  country, this will be its ISO 3166-1 alpha-3 code (e.g. 'bel' for Belgium);
+  and for a subdivision of a country, this will be its ISO 3166-2 code. This is
+  not yet the case.)
+
+- Inside `python/popgetter/assets/__init__.py`, import the new country
+  subdirectory as a module and add this module to the list of `countries`. This
+  allows Dagster to detect the assets belonging to the new country.
+
+- Define the requisite assets inside the country subdirectory, as will be
+  described below. Note that you can structure the code inside the country
+  subdirectory however you like (e.g. across multiple files), as Dagster will
+  load all the assets in that subdirectory.
+
+## Required assets
+
+There are, fundamentally, five assets which must be defined for each country.
+Their return types are fixed, but they can have any input types (i.e. you can
+construct the asset graph in any way you like).
+
+Three of these are metadata assets:
+
+- **Country metadata:** an asset which returns
+  `popgetter.metadata.CountryMetadata` object(s).
+- **Data publisher metadata:** an asset which returns
+  `popgetter.metadata.DataPublisher` object(s).
+- **Source release metadata:** an asset which returns
+  `popgetter.metadata.SourceDataRelease` object(s).
+
+These metadata assets can return either a single object, a list of objects, or a
+dictionary where the values are objects. This flexibility makes it easier to
+construct dependencies between assets in Dagster depending on your needs.
+
+- **Geometries:** an asset which returns a list of
+  `popgetter.cloud_outputs.GeometryOutput` objects
+
+A `GeometryOutput` is essentially a named tuple of
+`popgetter.metadata.GeometryMetadata` (which provides metadata about the
+geometry), a `geopandas.GeoDataFrame` object (which contains geoIDs and the
+geometries themselves), and a `pandas.DataFrame` object (which contains geoIDs
+and the names of the regions).
+
+Note that the GeoDataFrame must _only_ contain the geometries and the geoIDs,
+and the DataFrame must _only_ contain the geoIDs and the names of the regions.
+Additionally, the geoID column in both of these must be named `GEO_ID`; and the
+column names in the DataFrame must correspond to
+[lowercase ISO 639-3 codes](https://iso639-3.sil.org/code_tables/639/data).
+
+- **Metrics:** an asset which returns a list of
+  `popgetter.cloud_outputs.MetricsOutput` objects
+
+One `MetricsOutput` in turn comprises a list of
+`popgetter.metadata.MetricMetadata` classes (which provides metadata about the
+metric), and a `pandas.DataFrame` object (which contains the metric data). Each
+element of the metadata list will correspond to one of the columns in the
+DataFrame. The DataFrame must also contain a `GEO_ID` column, which contains the
+geoIDs that correspond to the geometries.
+
+This asset returns a _list_ of `MetricsOutput` objects because each of the the
+individual outputs will be serialised to a separate parquet file. The location
+of this parquet file is specified as part of the `MetricMetadata` object.
+
+(Note that because a `MetricMetadata` object includes an ID for the
+`SourceDataRelease` that it corresponds to, which _in turn_ contains an ID for
+the `GeometryMetadata`, each set of metrics can be tied to one geometry level.)
+
+## Publishing the assets
+
+Defining the assets and importing them should allow you to view the asset graph
+in the Dagster UI and materialise the assets. When the assets are materialised,
+Dagster will serialise their return values by pickling them and storing them
+inside the `$DAGSTER_HOME/storage` directory. However, these files are not
+suitable for consumption by downstream tasks such as the popgetter CLI: the CLI
+expects data and metadata to be provided in a specific format (see
+[Output structure](output_structure.md)).
+
+In the popgetter library, the pipeline which publishes (meta)data in the correct
+format is constructed using
+[sensors](https://docs.dagster.io/concepts/partitions-schedules-sensors/sensors).
+These sensors monitor a list of specified assets for materialisations, and will
+publish their return values in the correct format when new materialisations are
+observed. (As a bonus, if any of your assets do not have the correct return
+types or do not satisfy any of the extra stipulations above, the sensor will
+raise an error.)
+
+If the `ENV` environment variable is set to `prod`, the sensors will publish the
+data to an Azure blob storage container; otherwise, the data will be published
+to `$DAGSTER_HOME/cloud_outputs`. To publish to Azure you will also need to set
+the additional environment variable `SAS_TOKEN`.
+
+To attach your newly defined assets to the sensors, all you need to do is to
+import the following decorators:
+
+```python
+from popgetter.cloud_outputs import (
+    send_to_metadata_sensor,
+    send_to_geometry_sensor,
+    send_to_metrics_sensor,
+)
+```
+
+and decorate your assets with these. The three metadata assets will use the
+`send_to_metadata_sensor` decorator, and likewise for the others. Note that this
+decorator expects an asset as an input, so the decorator must be applied as the
+outermost decorator, i.e. _above_ Dagster's `@asset` decorator. For example:
+
+```python
+@send_to_metadata_sensor
+@asset(...)
+def country_metadata():
+    return CountryMetadata(...)
+```
+
+## `Country` base class
+
+To simplify the process of defining the assets and the associated relationships
+between them, we provide a `Country` base class which you can inherit from.
+These abstract away most of Dagster's implementation details, and mean that you
+only need to write the actual Python functions to process the data. For example,
+instead of the `country_metadata` asset above, you could write:
+
+```python
+from popgetter.assets.country import Country
+
+
+class MyCountry(Country):
+    def _country_metadata(self, context):
+        return CountryMetadata(...)
+
+
+my_country = MyCountry()
+country_metadata_asset = my_country.create_country_metadata()
+```
+
+The `create_country_metadata` method will generate a Dagster asset and register
+it with the metadata sensor for you. The reason why this line is necessary is
+that Dagster can only detect assets which are defined at the top level of any
+module: so, calling this method binds an asset to a top-level definition which
+can then be picked up.
+
+For an example of this, see the implementation of Northern Ireland data in
+`python/popgetter/assets/ni`.
+
+Naturally, the implementation of this base class makes some assumptions about
+the structure of the data and the relationships between them. We have found
+these to be applicable across multiple countries we have worked with. However,
+if these are not suitable for your data, you can still define the assets
+manually as shown above!

--- a/docs/new_country.md
+++ b/docs/new_country.md
@@ -157,4 +157,6 @@ Naturally, the implementation of this base class makes some assumptions about
 the structure of the data and the relationships between them. We have found
 these to be applicable across multiple countries we have worked with. However,
 if these are not suitable for your data, you can still define the assets
-manually as shown above! It is also possible to override part of the base class with manual asset implementations to include variations from the structure assumed by the base class.
+manually as shown above! It is also possible to override part of the base class
+with manual asset implementations to include variations from the structure
+assumed by the base class.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
   "beautifulsoup4 >=4.12.3", # For extracting catalogs from web pages
   "openpyxl >=3.1.3", # For reading Excel files
   "iso639-lang >=2.2.3", # For checking ISO639-3 language codes
+  "aiohttp >=3.9.5", # Async HTTP
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
   "jcs >=0.2.1", # For generating IDs from class attributes
   "beautifulsoup4 >=4.12.3", # For extracting catalogs from web pages
   "openpyxl >=3.1.3", # For reading Excel files
+  "iso639-lang >=2.2.3", # For checking ISO639-3 language codes
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
   "dagster-cloud >=1.6.11,<1.7.0", # Version matched to dagster (see above)
   "dagster-azure >=0.22.11",  # Only required for production deployments, could be moved to an optional
   "pandas >=2.1,<2.2", # Pinned to 2.1 as 2.2 might be causing the failure here https://github.com/Urban-Analytics-Technology-Platform/popgetter/actions/runs/7593850248/job/20684737578
-  "geopandas >=0.14.1", # This probably won't resolve to the latest version of geopandas, due to version restrictions pandas package (see above).
+  "geopandas >=0.14.1,<1", # Compatibility with 1.0 to be determined
   "docker",  # Use and version to be confirmed, see https://github.com/Urban-Analytics-Technology-Platform/popgetter/issues/38#issuecomment-2009350512
   "lxml >=4.9.3",  # Used by `download_from_wfs` function
   "pyarrow", # Used interface with polars-arrow

--- a/python/popgetter/__init__.py
+++ b/python/popgetter/__init__.py
@@ -7,6 +7,11 @@ from pathlib import Path
 
 from dagster import ExperimentalWarning
 
+# Has to be placed before imports as otherwise importing other modules will
+# trigger ExperimentalWarnings themselves...
+if "IGNORE_EXPERIMENTAL_WARNINGS" in os.environ:
+    warnings.filterwarnings("ignore", category=ExperimentalWarning)
+
 from popgetter.io_managers.azure import (
     AzureGeneralIOManager,
     AzureGeoIOManager,
@@ -23,10 +28,6 @@ from popgetter.utils import StagingDirResource
 __version__ = "0.1.0"
 
 __all__ = ["__version__"]
-
-
-if "IGNORE_EXPERIMENTAL_WARNINGS" in os.environ:
-    warnings.filterwarnings("ignore", category=ExperimentalWarning)
 
 
 import os

--- a/python/popgetter/assets/be/census_derived.py
+++ b/python/popgetter/assets/be/census_derived.py
@@ -252,7 +252,7 @@ def source_metrics_by_partition(
 def derived_metrics_by_partition(
     context,
     source_metrics_by_partition: tuple[MetricMetadata, pd.DataFrame],
-) -> tuple[list[MetricMetadata], pd.DataFrame]:
+) -> MetricsOutput:
     node = context.partition_key
 
     source_mmd, source_table = source_metrics_by_partition
@@ -312,7 +312,7 @@ def derived_metrics_by_partition(
         },
     )
 
-    return derived_mmd, joined_metrics
+    return MetricsOutput(metadata=derived_mmd, metrics=joined_metrics)
 
 
 @send_to_metrics_sensor
@@ -328,7 +328,8 @@ def derived_metrics_by_partition(
     key_prefix=asset_prefix,
 )
 def metrics(
-    context, derived_metrics_by_partition: tuple[list[MetricMetadata], pd.DataFrame]
+    context,
+    derived_metrics_by_partition: MetricsOutput,
 ) -> list[MetricsOutput]:
     """
     This asset exists solely to aggregate all the derived tables into one
@@ -337,13 +338,10 @@ def metrics(
     Right now it is a bit boring because it only relies on one partition, but
     it could be extended when we have more data products.
     """
-    mmds, table = derived_metrics_by_partition
-
     context.add_output_metadata(
         metadata={
-            "num_metrics": len(mmds),
+            "num_metrics": len(derived_metrics_by_partition.metadata),
             "num_parquets": 1,
         },
     )
-
-    return [MetricsOutput(metadata=mmds, metrics=table)]
+    return [derived_metrics_by_partition]

--- a/python/popgetter/assets/be/census_derived.py
+++ b/python/popgetter/assets/be/census_derived.py
@@ -15,7 +15,7 @@ from dagster import (
 )
 from icecream import ic
 
-from popgetter.cloud_outputs import send_to_metrics_sensor, MetricsOutput
+from popgetter.cloud_outputs import MetricsOutput, send_to_metrics_sensor
 from popgetter.metadata import MetricMetadata, SourceDataRelease, metadata_to_dataframe
 
 from .belgium import asset_prefix

--- a/python/popgetter/assets/be/census_derived.py
+++ b/python/popgetter/assets/be/census_derived.py
@@ -15,7 +15,7 @@ from dagster import (
 )
 from icecream import ic
 
-from popgetter.cloud_outputs import send_to_metrics_sensor
+from popgetter.cloud_outputs import send_to_metrics_sensor, MetricsOutput
 from popgetter.metadata import MetricMetadata, SourceDataRelease, metadata_to_dataframe
 
 from .belgium import asset_prefix
@@ -329,7 +329,7 @@ def derived_metrics_by_partition(
 )
 def metrics(
     context, derived_metrics_by_partition: tuple[list[MetricMetadata], pd.DataFrame]
-) -> list[tuple[str, list[MetricMetadata], pd.DataFrame]]:
+) -> list[MetricsOutput]:
     """
     This asset exists solely to aggregate all the derived tables into one
     single unpartitioned asset, which the downstream publishing tasks can use.
@@ -338,7 +338,6 @@ def metrics(
     it could be extended when we have more data products.
     """
     mmds, table = derived_metrics_by_partition
-    filepath = mmds[0].metric_parquet_path
 
     context.add_output_metadata(
         metadata={
@@ -347,4 +346,4 @@ def metrics(
         },
     )
 
-    return [(filepath, mmds, table)]
+    return [MetricsOutput(metadata=mmds, metrics=table)]

--- a/python/popgetter/assets/be/census_geometry.py
+++ b/python/popgetter/assets/be/census_geometry.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import date
 
-import geopandas as gpd
 import matplotlib.pyplot as plt
-import pandas as pd
 from dagster import (
     AssetIn,
     MetadataValue,
@@ -15,9 +13,9 @@ from dagster import (
 from icecream import ic
 
 from popgetter.cloud_outputs import (
+    GeometryOutput,
     send_to_geometry_sensor,
     send_to_metadata_sensor,
-    GeometryOutput,
 )
 from popgetter.metadata import (
     GeometryMetadata,
@@ -103,9 +101,7 @@ BELGIUM_GEOMETRY_LEVELS = {
     },
     key_prefix=asset_prefix,
 )
-def geometry(
-    context, sector_geometries
-) -> list[GeometryOutput]:
+def geometry(context, sector_geometries) -> list[GeometryOutput]:
     """
     Produces the full set of data / metadata associated with Belgian
     municipalities. The outputs, in order, are:
@@ -163,10 +159,14 @@ def geometry(
     context.add_output_metadata(
         metadata={
             "all_geom_levels": MetadataValue.md(
-                ",".join([geom_output.metadata.level for geom_output in geometries_to_return])
+                ",".join(
+                    [geom_output.metadata.level for geom_output in geometries_to_return]
+                )
             ),
             "first_geometry_plot": MetadataValue.md(md_plot),
-            "first_names_preview": MetadataValue.md(first_output.names_df.head().to_markdown()),
+            "first_names_preview": MetadataValue.md(
+                first_output.names_df.head().to_markdown()
+            ),
         }
     )
 

--- a/python/popgetter/assets/country.py
+++ b/python/popgetter/assets/country.py
@@ -16,6 +16,8 @@ from popgetter.cloud_outputs import (
     send_to_geometry_sensor,
     send_to_metadata_sensor,
     send_to_metrics_sensor,
+    GeometryOutput,
+    MetricsOutput,
 )
 from popgetter.metadata import (
     CountryMetadata,
@@ -121,7 +123,7 @@ class Country(ABC):
     @abstractmethod
     def _geometry(
         self, context
-    ) -> list[tuple[GeometryMetadata, gpd.GeoDataFrame, pd.DataFrame]]:
+    ) -> list[GeometryOutput]:
         ...
 
     def create_source_data_releases(self):
@@ -134,7 +136,7 @@ class Country(ABC):
         @asset(key_prefix=self.key_prefix)
         def source_data_releases(
             context,
-            geometry: list[tuple[GeometryMetadata, gpd.GeoDataFrame, pd.DataFrame]],
+            geometry: list[GeometryOutput],
             data_publisher: DataPublisher,
         ) -> dict[str, SourceDataRelease]:
             return self._source_data_releases(context, geometry, data_publisher)
@@ -145,7 +147,7 @@ class Country(ABC):
     def _source_data_releases(
         self,
         context,
-        geometry: list[tuple[GeometryMetadata, gpd.GeoDataFrame, pd.DataFrame]],
+        geometry: list[GeometryOutput],
         data_publisher: DataPublisher,
         # TODO: consider version without inputs so only output type specified
         # **kwargs,
@@ -202,7 +204,7 @@ class Country(ABC):
             context,
             census_tables: pd.DataFrame,
             source_metric_metadata: MetricMetadata,
-        ) -> tuple[list[MetricMetadata], pd.DataFrame]:
+        ) -> MetricsOutput:
             return self._derived_metrics(context, census_tables, source_metric_metadata)
 
         return derived_metrics
@@ -213,7 +215,7 @@ class Country(ABC):
         context,
         census_tables: pd.DataFrame,
         source_metric_metadata: MetricMetadata,
-    ) -> tuple[list[MetricMetadata], pd.DataFrame]:
+    ) -> MetricsOutput:
         ...
 
     def create_metrics(
@@ -250,11 +252,11 @@ class Country(ABC):
         )
         def metrics(
             context,
-            # In principle:
-            # derived_metrics: dict[str, tuple[list[MetricMetadata], pd.DataFrame]] | tuple[list[MetricMetadata], pd.DataFrame],
-            # But Dagster doesn't like union types so we just use Any
+            # In principle, the derived_metrics should have the type:
+            #    dict[str, MetricsOutput] | MetricsOutput
+            # But Dagster doesn't like union types so we just use Any.
             derived_metrics,
-        ) -> list[tuple[str, list[MetricMetadata], pd.DataFrame]]:
+        ) -> list[MetricsOutput]:
             # If the input asset has multiple partitions, Dagster returns a
             # dictionary of {partition_key: output_value}. However, if only one
             # partition is required, Dagster passes only the output value of
@@ -278,17 +280,20 @@ class Country(ABC):
     def _metrics(
         self,
         context,
-        derived_metrics: dict[str, tuple[list[MetricMetadata], pd.DataFrame]],
-    ) -> list[tuple[str, list[MetricMetadata], pd.DataFrame]]:
-        # Combine outputs across partitions
-        outputs = [
-            (mmds[0].metric_parquet_path, mmds, table)
-            for (mmds, table) in derived_metrics.values()
-            if len(mmds) > 0
-        ]
+        derived_metrics: dict[str, MetricsOutput],
+    ) -> list[MetricsOutput]:
+        """
+        Method which aggregates all the outputs of the `derived_metrics` asset.
+        The default implementation simply combines each partition's output into
+        a list (ignoring any partitions which have empty outputs). This is
+        typically all that is required; however, this method can be overridden
+        if different logic is required.
+        """
+        outputs = [output for output in derived_metrics.values()
+                   if len(output.metadata) > 0]
         context.add_output_metadata(
             metadata={
-                "num_metrics": sum(len(output[1]) for output in outputs),
+                "num_metrics": sum(len(output.metadata) for output in outputs),
                 "num_parquets": len(outputs),
             },
         )

--- a/python/popgetter/assets/country.py
+++ b/python/popgetter/assets/country.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import ClassVar
 
-import geopandas as gpd
 import pandas as pd
 from dagster import (
     AssetIn,
@@ -13,16 +12,15 @@ from dagster import (
 )
 
 from popgetter.cloud_outputs import (
+    GeometryOutput,
+    MetricsOutput,
     send_to_geometry_sensor,
     send_to_metadata_sensor,
     send_to_metrics_sensor,
-    GeometryOutput,
-    MetricsOutput,
 )
 from popgetter.metadata import (
     CountryMetadata,
     DataPublisher,
-    GeometryMetadata,
     MetricMetadata,
     SourceDataRelease,
 )
@@ -121,9 +119,7 @@ class Country(ABC):
         return geometry
 
     @abstractmethod
-    def _geometry(
-        self, context
-    ) -> list[GeometryOutput]:
+    def _geometry(self, context) -> list[GeometryOutput]:
         ...
 
     def create_source_data_releases(self):
@@ -289,8 +285,9 @@ class Country(ABC):
         typically all that is required; however, this method can be overridden
         if different logic is required.
         """
-        outputs = [output for output in derived_metrics.values()
-                   if len(output.metadata) > 0]
+        outputs = [
+            output for output in derived_metrics.values() if len(output.metadata) > 0
+        ]
         context.add_output_metadata(
             metadata={
                 "num_metrics": sum(len(output.metadata) for output in outputs),

--- a/python/popgetter/assets/ni/__init__.py
+++ b/python/popgetter/assets/ni/__init__.py
@@ -7,7 +7,9 @@ from dataclasses import dataclass
 from datetime import date
 from functools import reduce
 from typing import ClassVar
+import asyncio
 
+import aiohttp
 import geopandas as gpd
 import matplotlib.pyplot as plt
 import pandas as pd
@@ -101,7 +103,7 @@ TABLES_TO_PROCESS = ["MS-A09", "DT-0018"] if os.getenv("ENV") == "dev" else None
 CENSUS_COLLECTION_DATE = date(2021, 3, 21)
 
 
-def get_nodes_and_links() -> dict[str, dict[str, str]]:
+async def get_nodes_and_links() -> dict[str, dict[str, str]]:
     """Extracts the URLs for census tables and metadata for ready-made tables."""
     SCHEME_AND_HOST = "https://build.nisra.gov.uk"
     urls = [
@@ -112,28 +114,33 @@ def get_nodes_and_links() -> dict[str, dict[str, str]]:
         if str(url.get("href")).startswith("/en/standard")
     ]
     nodes: dict[str, dict[str, str]] = {}
-    for url in urls:
-        soup = BeautifulSoup(requests.get(url).content, features="lxml")
-        nodes[url] = {
-            "table_url": next(
-                iter(
-                    [
-                        "".join([SCHEME_AND_HOST, link.get("href")])
-                        for link in soup.find_all("a")
-                        if "table.csv?" in link.get("href")
-                    ]
-                )
-            ),
-            "metadata_url": next(
-                iter(
-                    [
-                        "".join([SCHEME_AND_HOST, link.get("href")])
-                        for link in soup.find_all("a")
-                        if "table.csv-metadata" in link.get("href")
-                    ]
-                )
-            ),
-        }
+    async def get_links(url: str, session: ClientSession) -> dict[str, str]:
+        async with session.get(url) as response:
+            soup = BeautifulSoup(await response.text(), features="lxml")
+            return {
+                "table_url": next(
+                    iter(
+                        [
+                            "".join([SCHEME_AND_HOST, link.get("href")])
+                            for link in soup.find_all("a")
+                            if "table.csv?" in link.get("href")
+                        ]
+                    )
+                ),
+                "metadata_url": next(
+                    iter(
+                        [
+                            "".join([SCHEME_AND_HOST, link.get("href")])
+                            for link in soup.find_all("a")
+                            if "table.csv-metadata" in link.get("href")
+                        ]
+                    )
+                ),
+            }
+    async with aiohttp.ClientSession() as session:
+        async with asyncio.TaskGroup() as tg:
+                tasks = {url: tg.create_task(get_links(url, session)) for url in urls}
+        nodes = {url: task.result() for url, task in tasks.items()}
     return nodes
 
 
@@ -263,6 +270,9 @@ class NorthernIreland(Country):
         )
 
     def _catalog(self, context) -> pd.DataFrame:
+        return asyncio.run(self._catalog_async(context))
+
+    async def _catalog_async(self, context) -> pd.DataFrame:
         """
         A catalog for NI can be generated in two ways:
         1. With flexible table builder:
@@ -294,7 +304,7 @@ class NorthernIreland(Country):
             "source_documentation_url": [],
             "table_schema": [],
         }
-        nodes = get_nodes_and_links()
+        nodes = await get_nodes_and_links()
         self.remove_all_partition_keys(context)
 
         def add_resolution(s: str, geo_level: str) -> str:
@@ -310,38 +320,50 @@ class NorthernIreland(Country):
             ic(out_url)
             return out_url
 
-        for node_url, node_items in nodes.items():
-            for geo_level in self.geo_levels:
-                metadata = requests.get(node_items["metadata_url"]).json()
+        async def get_catalog_summary(node_url: str,
+                                      node_items: dict[str, str],
+                                      geo_level: str,
+                                      session: aiohttp.ClientSession):
+            async with session.get(node_items["metadata_url"]) as response:
+                metadata = await response.json()
                 table_id = metadata["dc:title"].split(":")[0]
                 # Skip if not required
                 if (
                     self.tables_to_process is not None
                     and table_id not in self.tables_to_process
                 ):
-                    continue
+                    return None
+                return {
+                    "node": node_url,
+                    "table_id": table_id,
+                    "geo_level": geo_level,
+                    "partition_key": f"{geo_level}/{table_id}",
+                    "human_readable_name": metadata["dc:title"],
+                    "description": metadata["dc:description"],
+                    "metric_parquet_file_url": None,
+                    "parquet_column_name": None,
+                    "parquet_margin_of_error_column": None,
+                    "parquet_margin_of_error_file": None,
+                    "potential_denominator_ids": None,
+                    "parent_metric_id": None,
+                    "source_data_release_id": None,
+                    "source_download_url": add_resolution(metadata["url"], geo_level),
+                    "source_format": None,
+                    "source_archive_file_path": None,
+                    "source_documentation_url": node_url,
+                    "table_schema": metadata["tableSchema"]
+                }
 
-                catalog_summary["node"].append(node_url)
-                catalog_summary["table_id"].append(table_id)
-                catalog_summary["geo_level"].append(geo_level)
-                catalog_summary["partition_key"].append(f"{geo_level}/{table_id}")
-                catalog_summary["human_readable_name"].append(metadata["dc:title"])
-                catalog_summary["description"].append(metadata["dc:description"])
-                catalog_summary["metric_parquet_file_url"].append(None)
-                catalog_summary["parquet_column_name"].append(None)
-                catalog_summary["parquet_margin_of_error_column"].append(None)
-                catalog_summary["parquet_margin_of_error_file"].append(None)
-                catalog_summary["potential_denominator_ids"].append(None)
-                catalog_summary["parent_metric_id"].append(None)
-                catalog_summary["source_data_release_id"].append(None)
-                catalog_summary["source_download_url"].append(
-                    add_resolution(metadata["url"], geo_level)
-                )
-                catalog_summary["source_format"].append(None)
-                catalog_summary["source_archive_file_path"].append(None)
-                catalog_summary["source_documentation_url"].append(node_url)
-                catalog_summary["table_schema"].append(metadata["tableSchema"])
-
+        async with aiohttp.ClientSession() as session:
+            async with asyncio.TaskGroup() as tg:
+                tasks = [tg.create_task(get_catalog_summary(node_url, node_items,
+                                                            geo_level,
+                                                            session))
+                         for node_url, node_items in nodes.items()
+                         for geo_level in self.geo_levels]
+        catalog_summary = [task.result() for task in tasks]
+        # Remove the empty results for partitions that weren't required
+        catalog_summary = [v for v in catalog_summary if v is not None]
         catalog_df = pd.DataFrame.from_records(catalog_summary)
         self.add_partition_keys(context, catalog_df["partition_key"].to_list())
 

--- a/python/popgetter/cloud_outputs/__init__.py
+++ b/python/popgetter/cloud_outputs/__init__.py
@@ -1,8 +1,33 @@
 from __future__ import annotations
+from dataclasses import dataclass
 
 from dagster import AssetsDefinition
 
 from .sensor_class import CloudAssetSensor
+
+
+@dataclass
+class GeometryOutput:
+    """This class conceptualises the expected output types of a geometry
+    asset. Specifically, the asset marked with @send_to_geometry_sensor has to
+    output a list of GeometryOutput objects (one per geometry level / year)."""
+
+    metadata: GeometryMetadata
+    gdf: gpd.GeoDataFrame
+    names_df: pd.DataFrame
+
+
+@dataclass
+class MetricsOutput:
+    """This class conceptualises the expected output types of a metrics
+    asset. Specifically, the asset marked with @send_to_metrics_sensor has to
+    output a list of MetricsOutput objects (one per parquet file; but each
+    MetricsOutput object may correspond to multiple metrics that are serialised
+    to the same parquet file)."""
+
+    metadata: list[MetricMetadata]
+    metrics: pd.DataFrame
+
 
 metadata_factory = CloudAssetSensor(
     io_manager_key="metadata_io_manager",

--- a/python/popgetter/cloud_outputs/__init__.py
+++ b/python/popgetter/cloud_outputs/__init__.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 
+import geopandas as gpd
+import pandas as pd
 from dagster import AssetsDefinition
+
+from popgetter.metadata import GeometryMetadata, MetricMetadata
 
 from .sensor_class import CloudAssetSensor
 

--- a/python/popgetter/cloud_outputs/__init__.py
+++ b/python/popgetter/cloud_outputs/__init__.py
@@ -14,7 +14,7 @@ from .sensor_class import CloudAssetSensor
 @dataclass
 class GeometryOutput:
     """This class conceptualises the expected output types of a geometry
-    asset. Specifically, the asset marked with @send_to_geometry_sensor has to
+    asset. Specifically, the asset marked with `@send_to_geometry_sensor` has to
     output a list of GeometryOutput objects (one per geometry level / year)."""
 
     metadata: GeometryMetadata
@@ -25,7 +25,7 @@ class GeometryOutput:
 @dataclass
 class MetricsOutput:
     """This class conceptualises the expected output types of a metrics
-    asset. Specifically, the asset marked with @send_to_metrics_sensor has to
+    asset. Specifically, the asset marked with `@send_to_metrics_sensor` has to
     output a list of MetricsOutput objects (one per parquet file; but each
     MetricsOutput object may correspond to multiple metrics that are serialised
     to the same parquet file)."""

--- a/python/popgetter/cloud_outputs/sensor_class.py
+++ b/python/popgetter/cloud_outputs/sensor_class.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 from dagster import (
     AssetKey,
     AssetSelection,
+    DagsterInstance,
     DefaultSensorStatus,
     DynamicPartitionsDefinition,
     Output,
     RunRequest,
-    DagsterInstance,
     asset,
     multi_asset_sensor,
 )

--- a/python/popgetter/cloud_outputs/sensor_class.py
+++ b/python/popgetter/cloud_outputs/sensor_class.py
@@ -7,6 +7,7 @@ from dagster import (
     DynamicPartitionsDefinition,
     Output,
     RunRequest,
+    DagsterInstance,
     asset,
     multi_asset_sensor,
 )
@@ -23,12 +24,6 @@ class CloudAssetSensor:
 
     Arguments
     ---------
-
-    `asset_names_to_monitor`: list[str]
-        A list of asset names in the country pipelines that we want to monitor.
-        Each asset name should be a single string and should be prefixed with
-        the asset group name and a forward slash (e.g. 'be/geometry').
-
     `io_manager_key`: str
         The key of the IO manager used for publishing. See the 'resources' and
         'resources_by_env' dicts in python/popgetter/__init__.py.
@@ -43,12 +38,10 @@ class CloudAssetSensor:
 
     def __init__(
         self,
-        # asset_names_to_monitor: list[str],
         io_manager_key: str,
         prefix: str,
         interval: int,
     ):
-        # self.asset_names_to_monitor = asset_names_to_monitor
         self.io_manager_key = io_manager_key
         self.publishing_asset_name = f"publish_{prefix}"
         self.sensor_name = f"sensor_{prefix}"
@@ -59,6 +52,16 @@ class CloudAssetSensor:
         self.partition_definition = DynamicPartitionsDefinition(
             name=self.partition_definition_name
         )
+        # Upon initialisation, remove all partitions so that the web UI doesn't
+        # show any stray partitions left over from old Dagster launches (this
+        # can happen when e.g. switching between different git branches)
+        with DagsterInstance.get() as instance:
+            for partition_key in instance.get_dynamic_partitions(
+                self.partition_definition_name
+            ):
+                instance.delete_dynamic_partition(
+                    self.partition_definition_name, partition_key
+                )
 
     def create_publishing_asset(self):
         @asset(

--- a/python/popgetter/io_managers/__init__.py
+++ b/python/popgetter/io_managers/__init__.py
@@ -6,7 +6,9 @@ import geopandas as gpd
 import pandas as pd
 from dagster import InputContext, IOManager, MetadataValue, OutputContext
 from upath import UPath
+from iso639 import iter_langs
 
+from popgetter.cloud_outputs import GeometryOutput, MetricsOutput
 from popgetter.metadata import (
     CountryMetadata,
     DataPublisher,
@@ -15,6 +17,9 @@ from popgetter.metadata import (
     SourceDataRelease,
     metadata_to_dataframe,
 )
+
+# Set of all valid ISO 639-3 codes. (They are all lowercase)
+VALID_ISO639_3_CODES = set(lang.pt3 for lang in iter_langs())
 
 
 class IOManagerError(Exception):
@@ -73,18 +78,31 @@ class MetadataIOManager(PopgetterIOManager):
             | dict[str, SourceDataRelease]
         ),
     ):
-        # Handling multiple obj types at runtime to simplify the DAG
+        def all_same_class_and_accepted(objs) -> bool:
+            return len(objs) > 0 and (
+                all(isinstance(obj, CountryMetadata) for obj in objs)
+                or all(isinstance(obj, DataPublisher) for obj in objs)
+                or all(isinstance(obj, SourceDataRelease) for obj in objs)
+            )
 
-        # TODO: add handling of: incorrect type of obj passed, empty dictionary and
-        # any other potential errors
-        if isinstance(obj, dict):
+        if isinstance(obj, dict) and all_same_class_and_accepted(obj.values()):
             vals = list(obj.values())
-        elif isinstance(obj, list):
+        elif isinstance(obj, list) and all_same_class_and_accepted(obj):
             vals = obj
-        else:
+        elif isinstance(obj, (CountryMetadata, DataPublisher, SourceDataRelease)):
             vals = [obj]
-        val = vals[0]
-        full_path = self.get_full_path(context, val)
+        else:
+            err_msg = (
+                "MetadataIOManager only accepts assets which produce"
+                " individual `CountryMetadata`, `DataPublisher`, or"
+                " `SourceDataRelease`; or lists of them; or dictionaries"
+                " with them as the values. If lists or dictionaries are"
+                " passed, they must be nonempty, and all items must be"
+                " of the same type."
+            )
+            raise ValueError(err_msg)
+
+        full_path = self.get_full_path(context, vals[0])
         context.add_output_metadata(metadata={"parquet_path": str(full_path)})
         self.handle_df(context, metadata_to_dataframe(vals), full_path)
 
@@ -149,7 +167,7 @@ class GeoIOManager(PopgetterIOManager):
     def handle_output(
         self,
         context: OutputContext,
-        obj: list[tuple[GeometryMetadata, gpd.GeoDataFrame, pd.DataFrame]],
+        obj: list[GeometryOutput],
     ) -> None:
         output_metadata = {
             "flatgeobuf_paths": [],
@@ -158,13 +176,55 @@ class GeoIOManager(PopgetterIOManager):
             "names_paths": [],
         }
 
-        for geo_metadata, gdf, names_df in obj:
-            full_paths = self.get_full_paths_geoms(context, geo_metadata)
+        for output in obj:
+            # Perform checks on input data
+            if set(output.gdf.columns) != {"GEO_ID", "geometry"}:
+                err_msg = (
+                    "The geodataframe passed to GeometryIOManager must"
+                    " have only two columns, 'GEO_ID' and 'geometry'."
+                )
+                raise ValueError(err_msg)
+            names_cols = set(output.names_df.columns)
+            if "GEO_ID" not in names_cols:
+                # Check if it's the index, reset index if so
+                if output.names_df.index.name == "GEO_ID":
+                    output.names_df = output.names_df.reset_index()
+                    names_cols = set(output.names_df.columns)
+                else:
+                    err_msg = (
+                        "The dataframe of names passed to GeometryIOManager"
+                        " must have a 'GEO_ID' column."
+                    )
+                    raise ValueError(err_msg)
+            other_names_cols = names_cols - {"GEO_ID"}
+            if len(other_names_cols) == 0:
+                err_msg = (
+                    "The dataframe of names passed to GeometryIOManager"
+                    " must have at least one column other than 'GEO_ID'."
+                )
+                raise ValueError(err_msg)
+            else:
+                not_iso639_3_cols = [
+                    col for col in other_names_cols if col not in VALID_ISO639_3_CODES
+                ]
+                if len(not_iso639_3_cols) > 0:
+                    err_msg = (
+                        f"The names of the column(s)"
+                        f" {not_iso639_3_cols} in the dataframe of"
+                        f" names passed to GeometryIOManager are not"
+                        f" valid ISO 639-3 codes."
+                    )
+                    raise ValueError(err_msg)
+            # Coerce columns to strings (pandas doesn't do this automatically)
+            output.gdf["GEO_ID"] = output.gdf["GEO_ID"].astype("string")
+            output.names_df = output.names_df.astype("string")
 
-            self.handle_flatgeobuf(context, gdf, full_paths.flatgeobuf)
-            self.handle_geojsonseq(context, gdf, full_paths.geojsonseq)
-            # TODO self.handle_pmtiles(context, gdf, full_paths.pmtiles)
-            self.handle_df(context, names_df, full_paths.names)
+            full_paths = self.get_full_paths_geoms(context, output.metadata)
+
+            self.handle_flatgeobuf(context, output.gdf, full_paths.flatgeobuf)
+            self.handle_geojsonseq(context, output.gdf, full_paths.geojsonseq)
+            # TODO self.handle_pmtiles(context, output.gdf, full_paths.pmtiles)
+            self.handle_df(context, output.names_df, full_paths.names)
 
             output_metadata["flatgeobuf_paths"].append(str(full_paths.flatgeobuf))
             output_metadata["pmtiles_paths"].append(str(full_paths.pmtiles))
@@ -172,7 +232,7 @@ class GeoIOManager(PopgetterIOManager):
             output_metadata["names_paths"].append(str(full_paths.names))
 
         metadata_df_filepath = self.get_full_path_metadata(context)
-        metadata_df = metadata_to_dataframe([md for md, _, _ in obj])
+        metadata_df = metadata_to_dataframe([geo_output.metadata for geo_output in obj])
         self.handle_df(context, metadata_df, metadata_df_filepath)
 
         context.add_output_metadata(
@@ -205,29 +265,79 @@ class MetricsIOManager(PopgetterIOManager):
     def handle_output(
         self,
         context: OutputContext,
-        obj: list[tuple[str, list[MetricMetadata], pd.DataFrame]],
+        obj: list[MetricsOutput],
     ) -> None:
+        # Perform checks on input data
+        all_filepaths = []
+        for output in obj:
+            # Check GEO_ID col
+            metrics_cols = set(output.metrics.columns)
+            if "GEO_ID" not in metrics_cols:
+                # Check if it's the index, reset index if so
+                if output.metrics.index.name == "GEO_ID":
+                    output.metrics = output.metrics.reset_index()
+                    metrics_cols = set(output.metrics.columns)
+                else:
+                    err_msg = (
+                        "The dataframe of metrics passed to MetricsIOManager"
+                        " must have a 'GEO_ID' column. It only has columns"
+                        f" {metrics_cols}."
+                    )
+                    raise ValueError(err_msg)
+            other_metrics_cols = metrics_cols - {"GEO_ID"}
+            # The data column names must match the metadata
+            metadata_cols = set(mmd.parquet_column_name for mmd in output.metadata)
+            if other_metrics_cols != metadata_cols:
+                err_msg = (
+                    "The dataframe of metrics passed to MetricsIOManager"
+                    " must have the same columns as the metadata"
+                    " specifies. The metadata specifies columns"
+                    f" {metadata_cols}, but the dataframe has columns"
+                    f" {other_metrics_cols}."
+                )
+                raise ValueError(err_msg)
+            # In each tuple, the list of MetricMetadata must all have the same
+            # filepath, as the corresponding dataframe is saved to that path
+            this_mmd_filepaths = set(mmd.metric_parquet_path for mmd in output.metadata)
+            if len(this_mmd_filepaths) != 1:
+                err_msg = (
+                    "The list of MetricMetadata in each tuple passed to"
+                    " MetricsIOManager must all have the same"
+                    " `metric_parquet_path`."
+                )
+                raise ValueError(err_msg)
+            # Check that it's not already been used
+            this_filepath = this_mmd_filepaths.pop()
+            if this_filepath in all_filepaths:
+                err_msg = (
+                    "Each MetricsOutput passed to MetricsIOManager must have a"
+                    f" unique `metric_parquet_path`. The path {this_filepath}"
+                    " is repeated."
+                )
+            all_filepaths.append(this_filepath)
+        # Convert GEO_ID cols to strings
+        for output in obj:
+            output.metrics["GEO_ID"] = output.metrics["GEO_ID"].astype("string")
+
         # Aggregate all the MetricMetadatas into a single dataframe, then
         # serialise
         all_metadatas_df = metadata_to_dataframe(
-            [md for _, per_file_metadatas, _ in obj for md in per_file_metadatas]
+            [m for metrics_output in obj for m in metrics_output.metadata]
         )
         metadata_df_filepath = self.get_full_path_metadata(context)
         self.handle_df(context, all_metadatas_df, metadata_df_filepath)
 
         # Write dataframes to the parquet files specified in the first element
         # of the tuple
-        for rel_path, _, df in obj:
+        for metrics_output in obj:
+            rel_path = metrics_output.metadata[0].metric_parquet_path
             full_path = self.get_full_path_metrics(context, rel_path)
-            self.handle_df(context, df, full_path)
+            self.handle_df(context, metrics_output.metrics, full_path)
 
         # Add metadata
         context.add_output_metadata(
             metadata={
-                "metric_parquet_paths": [
-                    str(self.get_full_path_metrics(context, rel_path))
-                    for rel_path, _, _ in obj
-                ],
+                "metric_parquet_paths": all_filepaths,
                 "num_metrics": len(all_metadatas_df),
                 "metric_human_readable_names": all_metadatas_df[
                     "human_readable_name"

--- a/python/popgetter/metadata.py
+++ b/python/popgetter/metadata.py
@@ -10,36 +10,59 @@ import pandas as pd
 from pydantic import BaseModel, Field, computed_field, model_validator
 
 
-def hash_class_vars(class_instance):
-    """
-    Calculate a SHA256 hash from a class instance's variables. Used for
-    generating unique and verifiable IDs for metadata classes.
+class MetadataBaseModel(BaseModel):
+    def hash_class_vars(self):
+        """
+        Calculate a SHA256 hash from a class instance's variables. Used for
+        generating unique and verifiable IDs for metadata classes.
 
-    Note that `vars()` does not include properties, so the IDs themselves are
-    not part of the hash, which avoids self-reference issues.
-    """
-    # Must copy the dict to avoid overriding the actual instance attributes!
-    # Because we're only modifying dates -> strings, we don't need to perform a
-    # deepcopy
-    variables = dict(**vars(class_instance))
-    # Python doesn't serialise dates to JSON, have to convert to ISO 8601 first
-    for key, val in variables.items():
-        if isinstance(val, date):
-            variables[key] = val.isoformat()
-    return sha256(jcs.canonicalize(variables)).hexdigest()
+        Note that `vars()` does not include properties, so the IDs themselves are
+        not part of the hash, which avoids self-reference issues.
+        """
+        # Must copy the dict to avoid overriding the actual instance attributes!
+        # Because we're only modifying dates -> strings, we don't need to perform a
+        # deepcopy
+        variables = dict(**vars(self))
+        # Python doesn't serialise dates to JSON, have to convert to ISO 8601 first
+        for key, val in variables.items():
+            if isinstance(val, date):
+                variables[key] = val.isoformat()
+        return sha256(jcs.canonicalize(variables)).hexdigest()
+
+    @classmethod
+    def fix_types(cls, df: pd.DataFrame) -> pd.DataFrame:
+        """
+        When a list of MetadataBaseModel classes is converted to a dataframe,
+        the types of the fields can be lost (notably, if all the values in a
+        column are None). This method is implemented on each class in order to
+        coerce the output dataframe columns to the correct types, so that the
+        subsequent serialisation to parquet will retain this type information.
+
+        In general, this function only needs to coerce columns which can be x
+        or None to the type x itself --- for example, `iso3166_2` on the
+        `CountryMetadata` class. For a column which is already a string (e.g.
+        `iso3`), it should not be possible to instantiate the class with a None
+        value, as Pydantic will raise an error.
+
+        The default implementation of this method is to do nothing and just
+        return the input dataframe. If a class needs to coerce types, it should
+        override this method and return the modified dataframe.
+        """
+        return df
 
 
 def metadata_to_dataframe(
-    metadata_instances: Sequence[BaseModel],
+    metadata_instances: Sequence[MetadataBaseModel],
 ):
     """
-    Convert a list of metadata instances to a pandas DataFrame. Any of the four
+    Convert a list of metadata instances to a pandas DataFrame. Any of the five
     metadata classes defined in this module can be used here.
     """
-    return pd.DataFrame([md.model_dump() for md in metadata_instances])
+    cls = metadata_instances[0].__class__
+    return cls.fix_types(pd.DataFrame([md.model_dump() for md in metadata_instances]))
 
 
-class CountryMetadata(BaseModel):
+class CountryMetadata(MetadataBaseModel):
     @computed_field
     @property
     def id(self) -> str:
@@ -63,8 +86,16 @@ class CountryMetadata(BaseModel):
         description="If the territory is a 'principal subdivision', its ISO 3166-2 code (for example 'BE-VLG')."
     )
 
+    @classmethod
+    def fix_types(cls, df: pd.DataFrame) -> pd.DataFrame:
+        return df.astype(
+            {
+                "iso3166_2": "string",
+            }
+        )
 
-class DataPublisher(BaseModel):
+
+class DataPublisher(MetadataBaseModel):
     @computed_field
     @property
     def id(self) -> str:
@@ -80,11 +111,11 @@ class DataPublisher(BaseModel):
     )
 
 
-class GeometryMetadata(BaseModel):
+class GeometryMetadata(MetadataBaseModel):
     @computed_field
     @property
     def id(self) -> str:
-        return hash_class_vars(self)
+        return self.hash_class_vars()
 
     @computed_field
     @property
@@ -107,11 +138,11 @@ class GeometryMetadata(BaseModel):
     )
 
 
-class SourceDataRelease(BaseModel):
+class SourceDataRelease(MetadataBaseModel):
     @computed_field
     @property
     def id(self) -> str:
-        return hash_class_vars(self)
+        return self.hash_class_vars()
 
     name: str = Field(
         description="The name of the data release, as given by the publisher"
@@ -153,11 +184,11 @@ class SourceDataRelease(BaseModel):
         return self
 
 
-class MetricMetadata(BaseModel):
+class MetricMetadata(MetadataBaseModel):
     @computed_field
     @property
     def id(self) -> str:
-        return hash_class_vars(self)
+        return self.hash_class_vars()
 
     human_readable_name: str = Field(
         description='A human readable name for the metric, something like "Total Population under 12 years old"'
@@ -201,6 +232,18 @@ class MetricMetadata(BaseModel):
     source_documentation_url: str = Field(
         description="The documentation of the data release in human readable form.",
     )
+
+    @classmethod
+    def fix_types(cls, df: pd.DataFrame) -> pd.DataFrame:
+        return df.astype(
+            {
+                "parquet_margin_of_error_column": "string",
+                "parquet_margin_of_error_file": "string",
+                "potential_denominator_ids": "object",
+                "parent_metric_id": "string",
+                "source_archive_file_path": "string",
+            }
+        )
 
 
 EXPORTED_MODELS = [

--- a/python/popgetter/metadata.py
+++ b/python/popgetter/metadata.py
@@ -99,7 +99,7 @@ class DataPublisher(MetadataBaseModel):
     @computed_field
     @property
     def id(self) -> str:
-        return hash_class_vars(self)
+        return self.hash_class_vars()
 
     name: str = Field(description="The name of the organisation publishing the data")
     url: str = Field(description="The url of the publisher's homepage.")


### PR DESCRIPTION
Commit messages have more detail, but the main changes of this PR are:

 - Closes #106
   - Fixes column types in published parquets, avoiding the `to_supertypes()` call in the CLI, see https://github.com/Urban-Analytics-Technology-Platform/popgetter-cli/pull/36#discussion_r1627541563

 - Closes #94 
   - Adds runtime checking to IO managers to make sure that the outputs have the correct types and conform to the specification
   - Small updates to NI and BE to conform to the new spec

 - Contributes towards #66 and #39
    - Adds a new documentation page on how to add a new country to popgetter. You can read this at https://popgetter--108.org.readthedocs.build/en/108/new_country/!

There is one commit (https://github.com/Urban-Analytics-Technology-Platform/popgetter/pull/108/commits/86746e584d3d598992144d9157e8d3b4efc4ab94) which converts the NI catalog requests to use async HTTP requests. I had to implement this not because of anything wrong with the original implementation, but rather because my Internet connection over here is not quite the same as in the UK... 🥲 However, I am happy to drop it from this PR if this is deemed unnecessary.