### PR TITLE
Update CD build environment to publish to PyPI / TestPyPI

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -65,7 +65,6 @@ jobs:
     permissions:
       id-token: write
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' && github.event.action == 'published'
 
     steps:
       - uses: actions/download-artifact@v4
@@ -78,3 +77,6 @@ jobs:
           # Remember to tell (test-)pypi about this repo before publishing
           # Remove this line to publish to PyPI
           repository-url: https://test.pypi.org/legacy/
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        if: github.event_name == 'release' && github.event.action == 'published'

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,6 +42,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Rust
+        run: rustup update stable && rustup default stable
+
       - uses: pypa/cibuildwheel@v2.22
 
       - name: Upload wheels

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -45,7 +45,12 @@ jobs:
       - name: Set up Rust
         run: rustup update stable && rustup default stable
 
+      # Config options from https://cibuildwheel.pypa.io/en/stable/faq/#building-rust-wheels
       - uses: pypa/cibuildwheel@v2.22
+        env:
+          CIBW_BEFORE_ALL_LINUX: curl -sSf https://sh.rustup.rs | sh -s -- -y
+          CIBW_BEFORE_ALL_WINDOWS: rustup target add i686-pc-windows-msvc
+          CIBW_ENVIRONMENT_LINUX: "PATH=$HOME/.cargo/bin:$PATH"
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -58,10 +58,27 @@ jobs:
   #       with:
   #         path: wheelhouse/*.whl
 
-  upload_all:
+  upload_release:
     # needs: [build_wheels, make_sdist]
     needs: [make_sdist]
     environment: release
+    permissions:
+      id-token: write
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: artifact
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        if: github.event_name == 'release' && github.event.action == 'published'
+
+  upload_test:
+    # needs: [build_wheels, make_sdist]
+    needs: [make_sdist]
+    environment: testpypi
     permissions:
       id-token: write
     runs-on: ubuntu-latest
@@ -77,6 +94,3 @@ jobs:
           # Remember to tell (test-)pypi about this repo before publishing
           # Remove this line to publish to PyPI
           repository-url: https://test.pypi.org/legacy/
-
-      - uses: pypa/gh-action-pypi-publish@release/v1
-        if: github.event_name == 'release' && github.event.action == 'published'

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,37 +29,38 @@ jobs:
         with:
           path: dist/*.tar.gz
 
-  build_wheels:
-    name: Wheel on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+  # build_wheels:
+  #   name: Wheel on ${{ matrix.os }}
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       os: [ubuntu-latest, windows-latest, macos-latest]
 
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0
 
-      - name: Set up Rust
-        run: rustup update stable && rustup default stable
+  #     - name: Set up Rust
+  #       run: rustup update stable && rustup default stable
 
-      # Config options from https://cibuildwheel.pypa.io/en/stable/faq/#building-rust-wheels
-      - uses: pypa/cibuildwheel@v2.22
-        env:
-          CIBW_BEFORE_ALL_LINUX: curl -sSf https://sh.rustup.rs | sh -s -- -y
-          CIBW_BEFORE_ALL_WINDOWS: rustup target add i686-pc-windows-msvc
-          CIBW_ENVIRONMENT_LINUX: "PATH=$HOME/.cargo/bin:$PATH"
-          CIBW_BUILD: cp311-* cp312-*
+  #     # Config options from https://cibuildwheel.pypa.io/en/stable/faq/#building-rust-wheels
+  #     - uses: pypa/cibuildwheel@v2.22
+  #       env:
+  #         CIBW_BEFORE_ALL_LINUX: curl -sSf https://sh.rustup.rs | sh -s -- -y
+  #         CIBW_BEFORE_ALL_WINDOWS: rustup target add i686-pc-windows-msvc
+  #         CIBW_ENVIRONMENT_LINUX: "PATH=$HOME/.cargo/bin:$PATH"
+  #         CIBW_BUILD: cp311-* cp312-*
 
-      - name: Upload wheels
-        uses: actions/upload-artifact@v4
-        with:
-          path: wheelhouse/*.whl
+  #     - name: Upload wheels
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         path: wheelhouse/*.whl
 
   upload_all:
-    needs: [build_wheels, make_sdist]
+    # needs: [build_wheels, make_sdist]
+    needs: [make_sdist]
     environment: release
     permissions:
       id-token: write

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -35,7 +35,7 @@ jobs:
     permissions:
       id-token: write
     runs-on: ubuntu-latest
-    # if: github.event_name == 'release' && github.event.action == 'published'
+    if: github.event_name == 'release' && github.event.action == 'published'
 
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -51,6 +51,7 @@ jobs:
           CIBW_BEFORE_ALL_LINUX: curl -sSf https://sh.rustup.rs | sh -s -- -y
           CIBW_BEFORE_ALL_WINDOWS: rustup target add i686-pc-windows-msvc
           CIBW_ENVIRONMENT_LINUX: "PATH=$HOME/.cargo/bin:$PATH"
+          CIBW_BUILD: cp311-* cp312-*
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,42 +29,13 @@ jobs:
         with:
           path: dist/*.tar.gz
 
-  # build_wheels:
-  #   name: Wheel on ${{ matrix.os }}
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       os: [ubuntu-latest, windows-latest, macos-latest]
-
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: 0
-
-  #     - name: Set up Rust
-  #       run: rustup update stable && rustup default stable
-
-  #     # Config options from https://cibuildwheel.pypa.io/en/stable/faq/#building-rust-wheels
-  #     - uses: pypa/cibuildwheel@v2.22
-  #       env:
-  #         CIBW_BEFORE_ALL_LINUX: curl -sSf https://sh.rustup.rs | sh -s -- -y
-  #         CIBW_BEFORE_ALL_WINDOWS: rustup target add i686-pc-windows-msvc
-  #         CIBW_ENVIRONMENT_LINUX: "PATH=$HOME/.cargo/bin:$PATH"
-  #         CIBW_BUILD: cp311-* cp312-*
-
-  #     - name: Upload wheels
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         path: wheelhouse/*.whl
-
   upload_release:
-    # needs: [build_wheels, make_sdist]
     needs: [make_sdist]
     environment: release
     permissions:
       id-token: write
     runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
 
     steps:
       - uses: actions/download-artifact@v4
@@ -73,10 +44,8 @@ jobs:
           path: dist
 
       - uses: pypa/gh-action-pypi-publish@release/v1
-        if: github.event_name == 'release' && github.event.action == 'published'
 
   upload_test:
-    # needs: [build_wheels, make_sdist]
     needs: [make_sdist]
     environment: testpypi
     permissions:
@@ -91,6 +60,4 @@ jobs:
 
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          # Remember to tell (test-)pypi about this repo before publishing
-          # Remove this line to publish to PyPI
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -35,7 +35,7 @@ jobs:
     permissions:
       id-token: write
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' && github.event.action == 'published'
+    # if: github.event_name == 'release' && github.event.action == 'published'
 
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -61,3 +61,6 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+          # Only skip existing distributions on testpypi (not on pypi).
+          # See https://github.com/pypa/gh-action-pypi-publish?tab=readme-ov-file#tolerating-release-package-file-duplicates
+          skip-existing: true


### PR DESCRIPTION
This changes the GitHub Actions CD process such that `poppusher` is automatically published to  [PyPI](https://pypi.org/project/poppusher/) and [Test-PyPI](https://test.pypi.org/project/poppusher/)

* I've only done source distributions because (i) the priority was to get something up with that name, (ii) binary distributions were proving tricky for reasons, and (iii) installing the poppusher component from PyPI a bit of an edge case.
* Deployment to PyPI is automatic whenever a v* tag is pushed on the main branch.
* Deployment to Test-PyPI is less restricted - I haven't attempted to resolve semantic version numbering for test builds/publications at the moment, so that might be failures if two versions get published without the version number being explicitly incremented.
